### PR TITLE
ALBS-38: Added ability to save/replace noarch packages between different architectures

### DIFF
--- a/alws/crud.py
+++ b/alws/crud.py
@@ -22,6 +22,7 @@ from alws.schemas import (
     distro_schema, test_schema, release_schema
 )
 from alws.utils.distro_utils import create_empty_repo
+from alws.utils.noarch import save_noarch_packages
 
 
 __all__ = [
@@ -535,6 +536,8 @@ async def build_done(
         db.add_all(artifacts)
         db.add(build_task)
         await db.commit()
+
+    await save_noarch_packages(db, build_task)
 
     async with db.begin():
         rpms_result = await db.execute(select(models.BuildTaskArtifact).where(

--- a/alws/utils/noarch.py
+++ b/alws/utils/noarch.py
@@ -1,0 +1,110 @@
+import copy
+import typing
+
+import sqlalchemy
+from sqlalchemy.future import select
+from sqlalchemy.orm import Session, selectinload
+
+from alws import models
+from alws.config import settings
+from alws.constants import BuildTaskStatus
+from alws.utils.pulp_client import PulpClient
+
+
+__all__ = [
+    'get_noarch_packages',
+    'save_noarch_packages',
+]
+
+
+async def get_noarch_packages(
+        db: Session, build_task_ids: typing.List[int]) -> dict:
+    query = select(models.BuildTaskArtifact).where(sqlalchemy.and_(
+        models.BuildTaskArtifact.build_task_id.in_(build_task_ids),
+        models.BuildTaskArtifact.type == 'rpm',
+        models.BuildTaskArtifact.name.like('%.noarch.%'),
+        models.BuildTaskArtifact.name.not_like('%-debuginfo-%'),
+        models.BuildTaskArtifact.name.not_like('%-debugsource-%'),
+    ))
+    db_artifacts = await db.execute(query)
+    db_artifacts = db_artifacts.scalars().all()
+    noarch_packages = {
+        artifact.name: artifact.href
+        for artifact in db_artifacts
+    }
+    return noarch_packages
+
+
+async def save_noarch_packages(db: Session, build_task: models.BuildTask):
+    query = select(models.BuildTask).where(sqlalchemy.and_(
+        models.BuildTask.build_id == build_task.build_id,
+        models.BuildTask.index == build_task.index,
+    )).options(
+        selectinload(models.BuildTask.artifacts),
+        selectinload(models.BuildTask.build).selectinload(models.Build.repos),
+    )
+    pulp_client = PulpClient(
+        settings.pulp_host,
+        settings.pulp_user,
+        settings.pulp_password,
+    )
+    async with db.begin():
+        build_tasks = await db.execute(query)
+        build_tasks = build_tasks.scalars().all()
+        if not all(
+                BuildTaskStatus.is_finished(task.status)
+                for task in build_tasks):
+            return
+
+        build_task_ids = [task.id for task in build_tasks]
+        noarch_packages = await get_noarch_packages(db, build_task_ids)
+        if not noarch_packages:
+            return
+
+        repos_to_update = {}
+        new_noarch_artifacts = []
+        hrefs_to_add = list(noarch_packages.values())
+
+        for task in build_tasks:
+            if task.status in (BuildTaskStatus.FAILED,
+                               BuildTaskStatus.EXCLUDED):
+                continue
+            noarch = copy.deepcopy(noarch_packages)
+            hrefs_to_delete = []
+
+            # replace hrefs for existing artifacts in database
+            # and create new artifacts if they doesn't exist
+            for artifact in task.artifacts:
+                if artifact.name in noarch:
+                    hrefs_to_delete.append(artifact.href)
+                    artifact.href = noarch.pop(artifact.name)
+            for name, href in noarch.items():
+                new_noarch_artifacts.append(
+                    models.BuildTaskArtifact(
+                        build_task_id=task.id,
+                        name=name,
+                        type='rpm',
+                        href=href,
+                    )
+                )
+            repo_href = next(
+                repo.pulp_href for repo in build_task.build.repos
+                if repo.arch == task.arch
+                and repo.type == 'rpm'
+                and repo.debug is False
+            )
+            repos_to_update[repo_href] = {
+                'add': hrefs_to_add,
+                'remove': hrefs_to_delete,
+            }
+
+        db.add_all(build_tasks)
+        db.add_all(new_noarch_artifacts)
+        await db.commit()
+
+    for repo_href, content_dict in repos_to_update.items():
+        await pulp_client.modify_repository(
+            repo_to=repo_href,
+            add=content_dict['add'],
+            remove=content_dict['remove'],
+        )

--- a/alws/utils/noarch.py
+++ b/alws/utils/noarch.py
@@ -18,21 +18,25 @@ __all__ = [
 
 
 async def get_noarch_packages(
-        db: Session, build_task_ids: typing.List[int]) -> dict:
+    db: Session,
+    build_task_ids: typing.List[int]
+) -> typing.Tuple[dict, dict]:
     query = select(models.BuildTaskArtifact).where(sqlalchemy.and_(
         models.BuildTaskArtifact.build_task_id.in_(build_task_ids),
         models.BuildTaskArtifact.type == 'rpm',
         models.BuildTaskArtifact.name.like('%.noarch.%'),
-        models.BuildTaskArtifact.name.not_like('%-debuginfo-%'),
-        models.BuildTaskArtifact.name.not_like('%-debugsource-%'),
     ))
     db_artifacts = await db.execute(query)
     db_artifacts = db_artifacts.scalars().all()
-    noarch_packages = {
-        artifact.name: artifact.href
-        for artifact in db_artifacts
-    }
-    return noarch_packages
+    noarch_packages = {}
+    debug_noarch_packages = {}
+    for artifact in db_artifacts:
+        if '-debuginfo-' in artifact.name or '-debugsource-' in artifact.name:
+            debug_noarch_packages[artifact.name] = artifact.href
+            continue
+        noarch_packages[artifact.name] = artifact.href
+
+    return noarch_packages, debug_noarch_packages
 
 
 async def save_noarch_packages(db: Session, build_task: models.BuildTask):
@@ -57,20 +61,24 @@ async def save_noarch_packages(db: Session, build_task: models.BuildTask):
             return
 
         build_task_ids = [task.id for task in build_tasks]
-        noarch_packages = await get_noarch_packages(db, build_task_ids)
-        if not noarch_packages:
+        noarch_packages, debug_noarch_packages = await get_noarch_packages(
+            db, build_task_ids)
+        if not any((noarch_packages, debug_noarch_packages)):
             return
 
         repos_to_update = {}
         new_noarch_artifacts = []
         hrefs_to_add = list(noarch_packages.values())
+        debug_hrefs_to_add = list(debug_noarch_packages.values())
 
         for task in build_tasks:
             if task.status in (BuildTaskStatus.FAILED,
                                BuildTaskStatus.EXCLUDED):
                 continue
             noarch = copy.deepcopy(noarch_packages)
+            debug_noarch = copy.deepcopy(debug_noarch_packages)
             hrefs_to_delete = []
+            debug_hrefs_to_delete = []
 
             # replace hrefs for existing artifacts in database
             # and create new artifacts if they doesn't exist
@@ -78,7 +86,12 @@ async def save_noarch_packages(db: Session, build_task: models.BuildTask):
                 if artifact.name in noarch:
                     hrefs_to_delete.append(artifact.href)
                     artifact.href = noarch.pop(artifact.name)
-            for name, href in noarch.items():
+                if artifact.name in debug_noarch:
+                    debug_hrefs_to_delete.append(artifact.href)
+                    artifact.href = debug_noarch.pop(artifact.name)
+
+            artifacts_to_create = {**noarch, **debug_noarch}
+            for name, href in artifacts_to_create.items():
                 new_noarch_artifacts.append(
                     models.BuildTaskArtifact(
                         build_task_id=task.id,
@@ -87,16 +100,20 @@ async def save_noarch_packages(db: Session, build_task: models.BuildTask):
                         href=href,
                     )
                 )
-            repo_href = next(
-                repo.pulp_href for repo in build_task.build.repos
-                if repo.arch == task.arch
-                and repo.type == 'rpm'
-                and repo.debug is False
-            )
-            repos_to_update[repo_href] = {
-                'add': hrefs_to_add,
-                'remove': hrefs_to_delete,
-            }
+
+            for repo in build_task.build.repos:
+                if repo.arch != task.arch and repo.type != 'rpm':
+                    continue
+                repo_href = repo.pulp_href
+                add_content = hrefs_to_add
+                remove_content = hrefs_to_delete
+                if repo.debug:
+                    add_content = debug_hrefs_to_add
+                    remove_content = debug_hrefs_to_delete
+                repos_to_update[repo_href] = {
+                    'add': add_content,
+                    'remove': remove_content,
+                }
 
         db.add_all(build_tasks)
         db.add_all(new_noarch_artifacts)


### PR DESCRIPTION
- Added new module `alws/utils/noarch.py`
- Implemented functions for saving/replacing noarch packages between different architectures

Tested on packages `grub2` and `mingw-glib2`