### PR TITLE
ALBS-20: Added flag whether "oracle" is enabled.

### DIFF
--- a/alws/config.py
+++ b/alws/config.py
@@ -11,7 +11,8 @@ class Settings(BaseSettings):
     alts_host: str = 'http://alts-scheduler:8000'
     alts_token: str
 
-    packages_oracle_host: str = 'http://beholder-web:5000'
+    package_oracle_enabled: bool = True
+    packages_oracle_host: typing.Optional[str] = 'http://beholder-web:5000'
     packages_oracle_token: typing.Optional[str]
 
     redis_url: str = 'redis://redis:6379'


### PR DESCRIPTION
We may have a situation when the system that is predicting packages is
unavailable and we need to just create a release plan on our own. This
commit brings support for such case.