### PR TITLE
ALBS-85: Send a special code when build is already done

### DIFF
--- a/alws/errors.py
+++ b/alws/errors.py
@@ -2,6 +2,10 @@ class BuildError(Exception):
     pass
 
 
+class AlreadyBuiltError(Exception):
+    pass
+
+
 class DataNotFoundError(Exception):
     pass
 


### PR DESCRIPTION
Fix the case when build node tries to report task as built when it's
already marked so. Send 409 HTTP code in such case.