### PR TITLE
ALBS-71: Implement single deploy mechanism of new BS

### DIFF
--- a/alws/scripts/albs-gitea-listener/Dockerfile
+++ b/alws/scripts/albs-gitea-listener/Dockerfile
@@ -10,5 +10,6 @@ RUN cd /code && virtualenv -p python3.8 env && source env/bin/activate \
     && pip3 install -r /tmp/requirements.txt --no-cache-dir
 COPY ./albs-gitea-listener/* /code/
 COPY ./git_cacher/git_cacher.py /code/
+COPY ./alws /code/alws
 WORKDIR /code
 CMD ["/bin/bash", "-c", "source env/bin/activate && python gitea_listener.py"]


### PR DESCRIPTION
Because:
```
Traceback (most recent call last):
  File "gitea_listener.py", line 23, in <module>
    from git_cacher import load_redis_cache, save_redis_cache
  File "/code/git_cacher.py", line 9, in <module>
    from alws.utils.gitea import GiteaClient
ModuleNotFoundError: No module named 'alws'
```