### PR TITLE
ALBS-28. Dist macro should be automatically taken from a git tag.

### DIFF
--- a/alws/build_planner.py
+++ b/alws/build_planner.py
@@ -260,6 +260,8 @@ class BuildPlanner:
             mock_options: typing.Optional[dict[str, typing.Any]] = None,
             ref_platform_version: typing.Optional[str] = None):
         parsed_dist_macro = parse_git_ref('(el[\d]+_[\d]+)', ref.git_ref)
+        if mock_options is None:
+            mock_options = {'definitions': {}}
         dist_taken_by_user = mock_options['definitions'].get('dist', False)
         for platform in self._platforms:
             arch_tasks = []

--- a/alws/utils/parsing.py
+++ b/alws/utils/parsing.py
@@ -9,4 +9,4 @@ def parse_git_ref(pattern : str, git_ref : str):
     if match:
         return match.groups()[-1]
     else:
-        return None
+        return

--- a/alws/utils/parsing.py
+++ b/alws/utils/parsing.py
@@ -3,7 +3,7 @@ import re
 
 __all__ = ['parse_git_ref']
 
-def parse_git_ref(pattern : str, git_ref : str):
+def parse_git_ref(pattern: str, git_ref: str):
     re_pattern = re.compile(pattern)
     match = re_pattern.search(git_ref)
     if match:

--- a/alws/utils/parsing.py
+++ b/alws/utils/parsing.py
@@ -1,0 +1,12 @@
+import re
+
+
+__all__ = ['parse_git_ref']
+
+def parse_git_ref(pattern : str, git_ref : str):
+    re_pattern = re.compile(pattern)
+    match = re_pattern.search(git_ref)
+    if match:
+        return match.groups()[-1]
+    else:
+        return None


### PR DESCRIPTION
ALBS-28. Dist macro should be automatically taken from a git tag.
But if 'definitions.dist' is set this value will be used  instead of any parsed