### PR TITLE
Added exporting repodata for filesystem exporters.

### DIFF
--- a/alws/routers/repositories.py
+++ b/alws/routers/repositories.py
@@ -49,11 +49,7 @@ async def fs_export_repository(repository_ids: list,
         res = await get_urls_from_html(repo_url)
         for url in res:
             dir_rd = Path(repo_elem).parent / 'repodata'
-            print(dir_rd)
-            try:
-                os.makedirs(dir_rd, exist_ok=True)
-            except Exception as e:
-                pass
+            os.makedirs(dir_rd, exist_ok=True)
             await download_file(url, dir_rd / Path(url).name)
     return export_paths
 

--- a/alws/routers/repositories.py
+++ b/alws/routers/repositories.py
@@ -1,5 +1,11 @@
+import os
 import typing
+import aiohttp
+import aiofiles
+import urllib
+from pathlib import Path
 
+from lxml.html import document_fromstring
 from fastapi import APIRouter, Depends
 
 from alws import database
@@ -35,6 +41,37 @@ async def fs_export_repository(repository_ids: list,
                                db: database.Session = Depends(get_db)):
     export_task = await repo_exporter.create_pulp_exporters_to_fs(
         db, repository_ids)
-    export_paths = await repo_exporter.execute_pulp_exporters_to_fs(
+    export_data = await repo_exporter.execute_pulp_exporters_to_fs(
         db, export_task)
+    export_paths = list(export_data.keys())
+    for repo_elem, repo_data in export_data.items():
+        repo_url = urllib.parse.urljoin(repo_data, 'repodata/')
+        res = await get_urls_from_html(repo_url)
+        for url in res:
+            dir_rd = Path(repo_elem).parent / 'repodata'
+            print(dir_rd)
+            try:
+                os.makedirs(dir_rd, exist_ok=True)
+            except Exception as e:
+                pass
+            await download_file(url, dir_rd / Path(url).name)
     return export_paths
+
+
+async def get_urls_from_html(base_url: str):
+    async with aiohttp.ClientSession() as session:
+        async with session.get(base_url) as response:
+            response.raise_for_status()
+            content = await response.text()
+            doc = document_fromstring(content)
+            children_urls = [base_url + a.get('href')
+                             for a in doc.xpath('//a')]
+            return children_urls
+
+
+async def download_file(url: str, dest: str):
+    async with aiohttp.ClientSession() as session:
+        async with session.get(url) as response:
+            content = await response.content.read()
+        async with aiofiles.open(dest, 'wb') as f:
+            await f.write(content)

--- a/alws/utils/pulp_client.py
+++ b/alws/utils/pulp_client.py
@@ -324,7 +324,7 @@ class PulpClient:
     async def update_filesystem_exporter(self, fse_pulp_href: str,
                                          fse_name: str,
                                          fse_path: str,
-                                         fse_method: str='symlink'):
+                                         fse_method: str='hardlink'):
         endpoint = fse_pulp_href
         params = {
             'name': fse_name,

--- a/alws/utils/pulp_client.py
+++ b/alws/utils/pulp_client.py
@@ -173,6 +173,7 @@ class PulpClient:
         await self.wait_for_task(task['task'])
 
     async def create_rpm_publication(self, repository: str):
+        # Creates repodata for repositories in some way
         ENDPOINT = 'pulp/api/v3/publications/rpm/rpm/'
         payload = {'repository': repository}
         task = await self.make_post_request(ENDPOINT, data=payload)
@@ -359,7 +360,7 @@ class PulpClient:
             'repository_version': fse_repository_version
         }
         fse_task = await self.make_post_request(endpoint, params)
-        await pulp_client.wait_for_task(fse_task['task'])
+        await self.wait_for_task(fse_task['task'])
         return fse_repository_version
 
     async def get_repo_latest_version(self, repo_href: str):

--- a/alws/utils/repository.py
+++ b/alws/utils/repository.py
@@ -7,5 +7,8 @@ __all__ = ['generate_repository_path']
 def generate_repository_path(export_id: int, repo_name: str,
                              arch: str, debug: bool) -> Path:
     if debug:
-        arch = f'{arch}-debug'
-    return Path(str(export_id), repo_name, arch)
+        return Path(str(export_id), repo_name, 'debug', arch, 'Packages')
+    elif arch == 'src':
+        return Path(str(export_id), repo_name, 'Source', 'Packages')
+    else:
+        return Path(str(export_id), repo_name, arch, 'Packages')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,7 @@ services:
     volumes:
       - "./alws:/code/alws"
       - "./scripts:/code/scripts"
+      - "./volumes/pulp/exports:/srv/exports"
       - "./reference_data:/code/reference_data"
     command:
         bash -c 'source env/bin/activate &&

--- a/reference_data/platforms.yaml
+++ b/reference_data/platforms.yaml
@@ -70,6 +70,38 @@
       debug: false
       remote_sync_policy: on_demand
       repository_sync_policy: additive
+    - arch: i686
+      name: almalinux-8-highavailability
+      type: rpm
+      remote_url: https://repo.almalinux.org/vault/8/HighAvailability/i686/os/
+      production: true
+      debug: false
+      remote_sync_policy: on_demand
+      repository_sync_policy: additive
+    - arch: i686
+      name: almalinux-8-resilientstorage
+      type: rpm
+      remote_url: https://repo.almalinux.org/vault/8/ResilientStorage/i686/os/
+      production: true
+      debug: false
+      remote_sync_policy: on_demand
+      repository_sync_policy: additive
+    - arch: i686
+      name: almalinux-8-devel
+      type: rpm
+      remote_url: https://repo.almalinux.org/vault/8/devel/i686/os/
+      production: true
+      debug: false
+      remote_sync_policy: on_demand
+      repository_sync_policy: additive
+    - arch: i686
+      name: almalinux-8-extras
+      type: rpm
+      remote_url: https://repo.almalinux.org/vault/8/extras/i686/os/
+      production: true
+      debug: false
+      remote_sync_policy: on_demand
+      repository_sync_policy: additive
     - arch: x86_64
       name: almalinux-8-baseos
       type: rpm
@@ -94,6 +126,38 @@
       debug: false
       remote_sync_policy: on_demand
       repository_sync_policy: additive
+    - arch: x86_64
+      name: almalinux-8-highavailability
+      type: rpm
+      remote_url: https://repo.almalinux.org/almalinux/8/HighAvailability/x86_64/os/
+      production: true
+      debug: false
+      remote_sync_policy: on_demand
+      repository_sync_policy: additive
+    - arch: x86_64
+      name: almalinux-8-resilientstorage
+      type: rpm
+      remote_url: https://repo.almalinux.org/almalinux/8/ResilientStorage/x86_64/os/
+      production: true
+      debug: false
+      remote_sync_policy: on_demand
+      repository_sync_policy: additive
+    - arch: x86_64
+      name: almalinux-8-devel
+      type: rpm
+      remote_url: https://repo.almalinux.org/almalinux/8/devel/x86_64/os/
+      production: true
+      debug: false
+      remote_sync_policy: on_demand
+      repository_sync_policy: additive
+    - arch: x86_64
+      name: almalinux-8-extras
+      type: rpm
+      remote_url: https://repo.almalinux.org/almalinux/8/extras/x86_64/os/
+      production: true
+      debug: false
+      remote_sync_policy: on_demand
+      repository_sync_policy: additive
     - arch: aarch64
       name: almalinux-8-baseos
       type: rpm
@@ -114,6 +178,38 @@
       name: almalinux-8-powertools
       type: rpm
       remote_url: https://repo.almalinux.org/almalinux/8/PowerTools/aarch64/os/
+      production: true
+      debug: false
+      remote_sync_policy: on_demand
+      repository_sync_policy: additive
+    - arch: aarch64
+      name: almalinux-8-highavailability
+      type: rpm
+      remote_url: https://repo.almalinux.org/almalinux/8/HighAvailability/aarch64/os/
+      production: true
+      debug: false
+      remote_sync_policy: on_demand
+      repository_sync_policy: additive
+    - arch: aarch64
+      name: almalinux-8-resilientstorage
+      type: rpm
+      remote_url: https://repo.almalinux.org/almalinux/8/ResilientStorage/aarch64/os/
+      production: true
+      debug: false
+      remote_sync_policy: on_demand
+      repository_sync_policy: additive
+    - arch: aarch64
+      name: almalinux-8-devel
+      type: rpm
+      remote_url: https://repo.almalinux.org/almalinux/8/devel/aarch64/os/
+      production: true
+      debug: false
+      remote_sync_policy: on_demand
+      repository_sync_policy: additive
+    - arch: aarch64
+      name: almalinux-8-extras
+      type: rpm
+      remote_url: https://repo.almalinux.org/almalinux/8/extras/aarch64/os/
       production: true
       debug: false
       remote_sync_policy: on_demand
@@ -153,6 +249,38 @@
       debug: false
       remote_sync_policy: on_demand
       repository_sync_policy: additive
+    - arch: src
+      name: almalinux-8-highavailability
+      type: rpm
+      remote_url: https://repo.almalinux.org/almalinux/8/HighAvailability/Source/
+      production: true
+      debug: false
+      remote_sync_policy: on_demand
+      repository_sync_policy: additive
+    - arch: src
+      name: almalinux-8-resilientstorage
+      type: rpm
+      remote_url: https://repo.almalinux.org/almalinux/8/ResilientStorage/Source/
+      production: true
+      debug: false
+      remote_sync_policy: on_demand
+      repository_sync_policy: additive
+    - arch: src
+      name: almalinux-8-devel
+      type: rpm
+      remote_url: https://repo.almalinux.org/almalinux/8/devel/Source/
+      production: true
+      debug: false
+      remote_sync_policy: on_demand
+      repository_sync_policy: additive
+    - arch: src
+      name: almalinux-8-extras
+      type: rpm
+      remote_url: https://repo.almalinux.org/almalinux/8/extras/Source/
+      production: true
+      debug: false
+      remote_sync_policy: on_demand
+      repository_sync_policy: additive
     - name: almalinux-8-baseos-debuginfo
       arch: x86_64
       type: rpm
@@ -173,6 +301,38 @@
       arch: x86_64
       type: rpm
       remote_url: https://repo.almalinux.org/almalinux/8/PowerTools/debug/x86_64/
+      production: true
+      debug: true
+      remote_sync_policy: on_demand
+      repository_sync_policy: additive
+    - arch: x86_64
+      name: almalinux-8-highavailability-debuginfo
+      type: rpm
+      remote_url: https://repo.almalinux.org/almalinux/8/HighAvailability/debug/x86_64/
+      production: true
+      debug: true
+      remote_sync_policy: on_demand
+      repository_sync_policy: additive
+    - arch: x86_64
+      name: almalinux-8-resilientstorage-debuginfo
+      type: rpm
+      remote_url: https://repo.almalinux.org/almalinux/8/ResilientStorage/debug/x86_64/
+      production: true
+      debug: true
+      remote_sync_policy: on_demand
+      repository_sync_policy: additive
+    - arch: x86_64
+      name: almalinux-8-devel-debuginfo
+      type: rpm
+      remote_url: https://repo.almalinux.org/almalinux/8/devel/debug/x86_64/
+      production: true
+      debug: true
+      remote_sync_policy: on_demand
+      repository_sync_policy: additive
+    - arch: x86_64
+      name: almalinux-8-extras-debuginfo
+      type: rpm
+      remote_url: https://repo.almalinux.org/almalinux/8/extras/debug/x86_64/
       production: true
       debug: true
       remote_sync_policy: on_demand
@@ -201,6 +361,39 @@
       debug: true
       remote_sync_policy: on_demand
       repository_sync_policy: additive
+    - arch: aarch64
+      name: almalinux-8-highavailability-debuginfo
+      type: rpm
+      remote_url: https://repo.almalinux.org/almalinux/8/HighAvailability/debug/aarch64/
+      production: true
+      debug: true
+      remote_sync_policy: on_demand
+      repository_sync_policy: additive
+    - arch: aarch64
+      name: almalinux-8-resilientstorage-debuginfo
+      type: rpm
+      remote_url: https://repo.almalinux.org/almalinux/8/ResilientStorage/debug/aarch64/
+      production: true
+      debug: true
+      remote_sync_policy: on_demand
+      repository_sync_policy: additive
+    - arch: aarch64
+      name: almalinux-8-devel-debuginfo
+      type: rpm
+      remote_url: https://repo.almalinux.org/almalinux/8/devel/debug/aarch64/
+      production: true
+      debug: true
+      remote_sync_policy: on_demand
+      repository_sync_policy: additive
+    - arch: aarch64
+      name: almalinux-8-extras-debuginfo
+      type: rpm
+      remote_url: https://repo.almalinux.org/almalinux/8/extras/debug/aarch64/
+      production: true
+      debug: true
+      remote_sync_policy: on_demand
+      repository_sync_policy: additive
+
 - name: AlmaLinux-9
   distr_type: rhel
   distr_version: '9'

--- a/reference_data/platforms.yaml
+++ b/reference_data/platforms.yaml
@@ -442,132 +442,157 @@
     - arch: x86_64
       name: centos-9-baseos
       type: rpm
-      remote_url: http://mirror.facebook.net/centos-stream/9-stream/BaseOS/x86_64/os/
+      remote_url: https://mirror.facebook.net/centos-stream/9-stream/BaseOS/x86_64/os/
       production: false
       debug: false
     - arch: x86_64
       name: centos-9-appstream
       type: rpm
-      remote_url: http://mirror.facebook.net/centos-stream/9-stream/AppStream/x86_64/os/
+      remote_url: https://mirror.facebook.net/centos-stream/9-stream/AppStream/x86_64/os/
       production: false
       debug: false
     - arch: x86_64
       name: centos-9-crb
       type: rpm
-      remote_url: http://mirror.facebook.net/centos-stream/9-stream/CRB/x86_64/os/
+      remote_url: https://mirror.facebook.net/centos-stream/9-stream/CRB/x86_64/os/
       production: false
       debug: false
     - arch: x86_64
       name: centos-9-highavailability
       type: rpm
-      remote_url: http://mirror.facebook.net/centos-stream/9-stream/HighAvailability/x86_64/os/
+      remote_url: https://mirror.facebook.net/centos-stream/9-stream/HighAvailability/x86_64/os/
       production: false
       debug: false
     - arch: x86_64
       name: centos-9-resilientrtorage
       type: rpm
-      remote_url: http://mirror.facebook.net/centos-stream/9-stream/ResilientStorage/x86_64/os/
+      remote_url: https://mirror.facebook.net/centos-stream/9-stream/ResilientStorage/x86_64/os/
       production: false
       debug: false
     - arch: x86_64
       name: centos-9-nfv
       type: rpm
-      remote_url: http://mirror.facebook.net/centos-stream/9-stream/NFV/x86_64/os/
+      remote_url: https://mirror.facebook.net/centos-stream/9-stream/NFV/x86_64/os/
       production: false
       debug: false
     - arch: x86_64
       name: centos-9-rt
       type: rpm
-      remote_url: http://mirror.facebook.net/centos-stream/9-stream/RT/x86_64/os/
+      remote_url: https://mirror.facebook.net/centos-stream/9-stream/RT/x86_64/os/
+      production: false
+      debug: false
+    - arch: i686
+      name: centos-9-baseos
+      type: rpm
+      remote_url: https://mirror.facebook.net/centos-stream/9-stream/BaseOS/x86_64/os/
+      production: false
+      debug: false
+    - arch: i686
+      name: centos-9-appstream
+      type: rpm
+      remote_url: https://mirror.facebook.net/centos-stream/9-stream/AppStream/x86_64/os/
+      production: false
+      debug: false
+    - arch: i686
+      name: centos-9-crb
+      type: rpm
+      remote_url: https://mirror.facebook.net/centos-stream/9-stream/CRB/x86_64/os/
+      production: false
+      debug: false
+    - arch: i686
+      name: centos-9-highavailability
+      type: rpm
+      remote_url: https://mirror.facebook.net/centos-stream/9-stream/HighAvailability/x86_64/os/
+      production: false
+      debug: false
+    - arch: i686
+      name: centos-9-resilientrtorage
+      type: rpm
+      remote_url: https://mirror.facebook.net/centos-stream/9-stream/ResilientStorage/x86_64/os/
       production: false
       debug: false
     - arch: aarch64
       name: centos-9-baseos
       type: rpm
-      remote_url: http://mirror.facebook.net/centos-stream/9-stream/BaseOS/aarch64/os/
+      remote_url: https://mirror.facebook.net/centos-stream/9-stream/BaseOS/aarch64/os/
       production: false
       debug: false
     - arch: aarch64
       name: centos-9-appstream
       type: rpm
-      remote_url: http://mirror.facebook.net/centos-stream/9-stream/AppStream/aarch64/os/
+      remote_url: https://mirror.facebook.net/centos-stream/9-stream/AppStream/aarch64/os/
       production: false
       debug: false
     - arch: aarch64
       name: centos-9-crb
       type: rpm
-      remote_url: http://mirror.facebook.net/centos-stream/9-stream/CRB/aarch64/os/
+      remote_url: https://mirror.facebook.net/centos-stream/9-stream/CRB/aarch64/os/
       production: false
       debug: false
     - arch: aarch64
       name: centos-9-highavailability
       type: rpm
-      remote_url: http://mirror.facebook.net/centos-stream/9-stream/HighAvailability/aarch64/os/
+      remote_url: https://mirror.facebook.net/centos-stream/9-stream/HighAvailability/aarch64/os/
       production: false
       debug: false
     - arch: aarch64
-      name: centos-9-resilientrtorage
-      type: rpm
-      remote_url: http://mirror.facebook.net/centos-stream/9-stream/ResilientStorage/aarch64/os/
-      production: false
-      debug: false
     - arch: ppc64le
       name: centos-9-baseos
       type: rpm
-      remote_url: http://mirror.facebook.net/centos-stream/9-stream/BaseOS/ppc64le/os/
+      remote_url: https://mirror.facebook.net/centos-stream/9-stream/BaseOS/ppc64le/os/
       production: false
       debug: false
     - arch: ppc64le
       name: centos-9-appstream
       type: rpm
-      remote_url: http://mirror.facebook.net/centos-stream/9-stream/AppStream/ppc64le/os/
+      remote_url: https://mirror.facebook.net/centos-stream/9-stream/AppStream/ppc64le/os/
       production: false
       debug: false
     - arch: ppc64le
       name: centos-9-crb
       type: rpm
-      remote_url: http://mirror.facebook.net/centos-stream/9-stream/CRB/ppc64le/os/
+      remote_url: https://mirror.facebook.net/centos-stream/9-stream/CRB/ppc64le/os/
       production: false
       debug: false
     - arch: ppc64le
       name: centos-9-highavailability
       type: rpm
-      remote_url: http://mirror.facebook.net/centos-stream/9-stream/HighAvailability/ppc64le/os/
+      remote_url: https://mirror.facebook.net/centos-stream/9-stream/HighAvailability/ppc64le/os/
       production: false
       debug: false
     - arch: ppc64le
       name: centos-9-resilientrtorage
       type: rpm
-      remote_url: http://mirror.facebook.net/centos-stream/9-stream/ResilientStorage/ppc64le/os/
+      remote_url: https://mirror.facebook.net/centos-stream/9-stream/ResilientStorage/ppc64le/os/
       production: false
       debug: false
     - arch: s390x
       name: centos-9-baseos
       type: rpm
-      remote_url: http://mirror.facebook.net/centos-stream/9-stream/BaseOS/s390x/os/
+      remote_url: https://mirror.facebook.net/centos-stream/9-stream/BaseOS/s390x/os/
       production: false
       debug: false
     - arch: s390x
       name: centos-9-appstream
       type: rpm
-      remote_url: http://mirror.facebook.net/centos-stream/9-stream/AppStream/s390x/os/
+      remote_url: https://mirror.facebook.net/centos-stream/9-stream/AppStream/s390x/os/
       production: false
       debug: false
     - arch: s390x
       name: centos-9-crb
       type: rpm
-      remote_url: http://mirror.facebook.net/centos-stream/9-stream/CRB/s390x/os/
+      remote_url: https://mirror.facebook.net/centos-stream/9-stream/CRB/s390x/os/
       production: false
       debug: false
     - arch: s390x
       name: centos-9-highavailability
       type: rpm
-      remote_url: http://mirror.facebook.net/centos-stream/9-stream/HighAvailability/s390x/os/
+      remote_url: https://mirror.facebook.net/centos-stream/9-stream/HighAvailability/s390x/os/
       production: false
       debug: false
     - arch: s390x
       name: centos-9-resilientrtorage
       type: rpm
-      remote_url: http://mirror.facebook.net/centos-stream/9-stream/ResilientStorage/s390x/os/
+      remote_url: https://mirror.facebook.net/centos-stream/9-stream/ResilientStorage/s390x/os/
       production: false
       debug: false

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,11 +5,12 @@ psycopg2-binary==2.9.3
 pydantic==1.8.2
 SQLAlchemy==1.4.29
 aiohttp==3.8.1
+aiofiles==0.8.0
+aioredis==2.0.1
 PyJWT==2.3.0
 alembic==1.7.5
-aioredis==2.0.1
 pytest==6.2.5
 jmespath==0.10.0
-pytest==6.2.5
 PyYAML==5.4.1
+lxml==4.7.1
 syncer==1.3.0


### PR DESCRIPTION
Added a couple of libs. Also changed some volumes (web-server have to store repodata near exported repos by pulp). So the docker images albs-web-server_web_server_1 should be rebuilt.

For pulp config pulp/setting/setting.py we should use `ALLOWED_EXPORT_PATHS=['/srv/exports']` line to allow exporting