### PR TITLE
Devel modules can be built

### DIFF
--- a/alws/build_planner.py
+++ b/alws/build_planner.py
@@ -197,6 +197,9 @@ class BuildPlanner:
                     devel_module.set_arch_list(
                         self._request_platforms[platform.name]
                     )
+                    mock_options['module_enable'].append(
+                        f'{devel_module.name}:{devel_module.stream}'
+                    )
                     module_index.add_module(devel_module)
                 module_pulp_href, sha256 = await pulp_client.create_module(
                     module_index.render(),

--- a/alws/routers/build_node.py
+++ b/alws/routers/build_node.py
@@ -36,8 +36,6 @@ async def build_done(
         await build_node.build_done(db, build_done_)
     except AlreadyBuiltError:
         response.status_code = status.HTTP_409_CONFLICT
-    except Exception:
-        pass
     # need add some logic after discussing with team
     # await crud.add_distributions_after_rebuild(db, build_done)
     if build_done_.status == 'done':

--- a/alws/schemas/build_schema.py
+++ b/alws/schemas/build_schema.py
@@ -39,6 +39,14 @@ class BuildTaskRef(BaseModel):
     def ref_type_to_str(self):
         return BuildTaskRefType.to_text(self.ref_type)
 
+    def get_dev_module(self) -> 'BuildTaskRef':
+        model_copy = self.copy(deep=True)
+        model_copy.url = self.url.replace(
+            self.git_repo_name,
+            self.git_repo_name + '-devel'
+        )
+        return model_copy
+
     class Config:
         orm_mode = True
 

--- a/alws/utils/gitea.py
+++ b/alws/utils/gitea.py
@@ -6,6 +6,10 @@ import logging
 import aiohttp
 
 
+class ModuleNotFoundError(Exception):
+    pass
+
+
 def modules_yaml_path_from_url(url: str, ref: str, ref_type: str) -> str:
     repo_name = urllib.parse.urlparse(url).path.split('/')[-1]
     if repo_name.endswith('.git'):
@@ -24,7 +28,12 @@ async def download_modules_yaml(url: str, ref: str, ref_type: str) -> str:
     async with aiohttp.ClientSession() as session:
         async with session.get(template_path) as response:
             template = await response.text()
-            response.raise_for_status()
+            try:
+                response.raise_for_status()
+            except aiohttp.ClientResponseError as error:
+                if error.status == 404:
+                    raise ModuleNotFoundError()
+                raise
             return template
 
 

--- a/alws/utils/modularity.py
+++ b/alws/utils/modularity.py
@@ -83,33 +83,35 @@ class RpmArtifact(BaseModel):
         )
         result = re.search(regex, artifact)
         if not result:
-            return None
+            return
         return RpmArtifact(**result.groupdict())
+
+    @staticmethod
+    def from_pulp_model(rpm_pkg: dict) -> 'RpmArtifact':
+        return RpmArtifact(
+            name=rpm_pkg['name'],
+            epoch=int(rpm_pkg['epoch']),
+            version=rpm_pkg['version'],
+            release=rpm_pkg['release'],
+            arch=rpm_pkg['arch']
+        )
 
 
 class ModuleWrapper:
 
-    def __init__(self, index, module, stream):
-        self._index = index
-        self._module = module
+    def __init__(self, stream):
         self._stream = stream
 
     @classmethod
     def from_template(cls, template: str, name=None, stream=None):
-        index = Modulemd.ModuleIndex.new()
-        ret, _ = index.update_from_string(template, strict=True)
-        if not ret:
-            if not all([name, stream]):
-                raise ValueError('can not parse modules.yaml template')
-            stream = Modulemd.ModuleStreamV2.read_string(
+        if all([name, stream]):
+            md_stream = Modulemd.ModuleStreamV2.read_string(
                 template, True, name, stream)
-            if not stream:
-                raise ValueError('can not parse modules.yaml template')
-            index.add_module_stream(stream)
-        name = index.get_module_names()[0]
-        module = index.get_module(name)
-        stream = module.get_all_streams()[0]
-        return ModuleWrapper(index, module, stream)
+        else:
+            md_stream = Modulemd.ModuleStreamV2.read_string(template, True)
+        if not md_stream:
+            raise ValueError('can not parse modules.yaml template')
+        return ModuleWrapper(md_stream)
 
     def generate_new_version(self, platform_prefix: str) -> int:
         return int(platform_prefix + datetime.datetime.utcnow().strftime(
@@ -170,14 +172,11 @@ class ModuleWrapper:
                 component.add_restricted_arch(arch)
 
     def add_rpm_artifact(self, rpm_pkg: dict):
-        artifact = RpmArtifact(
-            name=rpm_pkg['name'],
-            epoch=int(rpm_pkg['epoch']),
-            version=rpm_pkg['version'],
-            release=rpm_pkg['release'],
-            arch=rpm_pkg['arch']
-        ).as_artifact()
-        if not self.is_artifact_filtered(artifact):
+        artifact = RpmArtifact.from_pulp_model(rpm_pkg).as_artifact()
+        if self.is_artifact_filtered(artifact):
+            if self.name.endswith('-devel'):
+                self._stream.add_rpm_artifact(artifact)
+        elif not self.name.endswith('-devel'):
             self._stream.add_rpm_artifact(artifact)
 
     def is_artifact_filtered(self, artifact: str) -> bool:
@@ -223,7 +222,9 @@ class ModuleWrapper:
                     yield module, stream
 
     def render(self) -> str:
-        return self._index.dump_to_string()
+        index = IndexWrapper()
+        index.add_module(self)
+        return index.render()
 
     @property
     def name(self) -> str:
@@ -256,3 +257,41 @@ class ModuleWrapper:
     @arch.setter
     def arch(self, arch: str):
         self._stream.set_arch(arch)
+
+
+class IndexWrapper:
+
+    def __init__(self, index=None):
+        if index is None:
+            index = Modulemd.ModuleIndex.new()
+        self._index = index
+
+    @staticmethod
+    def from_template(template: str):
+        index = Modulemd.ModuleIndex.new()
+        ret, _ = index.update_from_string(template, strict=True)
+        if not ret:
+            raise ValueError('can not parse modules.yaml template')
+        return IndexWrapper(index)
+
+    def get_module(self, name: str, stream: str) -> ModuleWrapper:
+        module = self._index.get_module(name)
+        for module_stream in module.get_all_streams():
+            if module_stream.get_stream_name() == stream:
+                return ModuleWrapper(module_stream)
+        raise ModuleNotFoundError(f'Index doesn\'t contain {name}:{stream}')
+
+    def add_module(self, module: ModuleWrapper):
+        self._index.add_module_stream(module._stream)
+
+    def iter_modules(self):
+        for module_name in self._index.get_module_names():
+            module = self._index.get_module(module_name)
+            for stream in module.get_all_streams():
+                yield ModuleWrapper(stream)
+
+    def render(self) -> str:
+        return self._index.dump_to_string()
+
+    def copy(self):
+        return self.from_template(self.render())


### PR DESCRIPTION
This commit allows building devel-modules alongside with default ones.
Whenever you're building module now, we'll check for it's devel version and build it together, if present

There are significant api changes in `alws/utils/modularity.py`:
* `class ModuleWrapper` now contains only one stream, without module/index (Initial implementation was backported from old bs and required changes to build multiple modules in one modules.yaml). You can't make new ModuleWrapper from string anymore if template has more than one module in it.
* `class IndexWrapper` (new class) is now should be used if you don't know for sure, how many module templates inside modules.yaml, or want to build multiple modules. All places in code, where we can find multiple modules at once, now using `IndexWrapper` instead of `ModuleWrapper`

`PulpClient.create_module` now requires name/stream/context/arch, while before it was trying to parse template with `ModuleWrapper` and figured out settings by itself, but since single template can have more than one module now, we're leaving this params for user to define.