### PR TITLE
ALBS-110: Fix empty streams based on mock options

### DIFF
--- a/alws/build_planner.py
+++ b/alws/build_planner.py
@@ -154,7 +154,12 @@ class BuildPlanner:
             settings.pulp_password
         )
         module = None
-        mock_options = {'definitions': {}}
+        if self._build.mock_options:
+            mock_options = self._build.mock_options.copy()
+            if not mock_options.get('definitions'):
+                mock_options['definitions'] = {}
+        else:
+            mock_options = {'definitions': {}}
         for platform in self._platforms:
             modularity_version = platform.modularity['versions'][-1]
             if task.module_platform_version:
@@ -164,6 +169,8 @@ class BuildPlanner:
                 )
             for arch in self._request_platforms[platform.name]:
                 module = ModuleWrapper.from_template(module_template)
+                module.add_module_dependencies_from_mock_defs(
+                    mock_modules=mock_options.get('module_enable', []))
                 mock_options['module_enable'] = [
                     f'{module.name}:{module.stream}'
                 ]

--- a/alws/crud/build.py
+++ b/alws/crud/build.py
@@ -23,6 +23,8 @@ async def create_build(
     async with db.begin():
         planner = BuildPlanner(db, user_id, build.platforms)
         await planner.load_platforms()
+        if build.mock_options:
+            planner.add_mock_options(build.mock_options)
         for task in build.tasks:
             await planner.add_task(task)
         if build.linked_builds:
@@ -30,8 +32,6 @@ async def create_build(
                 linked_build = await get_builds(db, linked_id)
                 if linked_build:
                     await planner.add_linked_builds(linked_build)
-        if build.mock_options:
-            planner.add_mock_options(build.mock_options)
         db_build = planner.create_build()
         db.add(db_build)
         await db.flush()

--- a/alws/utils/modularity.py
+++ b/alws/utils/modularity.py
@@ -121,6 +121,51 @@ class ModuleWrapper:
         hashes = '{0}:{1}'.format(build_context, runtime_context)
         return hashlib.sha1(hashes.encode('utf-8')).hexdigest()[:8]
 
+    def add_module_dependencies_from_mock_defs(self, mock_modules: list = None):
+        old_deps = Modulemd.Dependencies()
+        new_deps = Modulemd.Dependencies()
+        modules = []
+        if mock_modules:
+            for module in mock_modules:
+                module_name, module_stream = module.split(':')
+                modules.append((module_name, module_stream))
+        if self._stream.get_dependencies():
+            old_deps = self._stream.get_dependencies()[0]
+
+        # Override build time modules if needed
+        added_build_deps = []
+        for old_dep in old_deps.get_buildtime_modules():
+            streams = old_deps.get_buildtime_streams(old_dep)
+            if modules:
+                for module in modules:
+                    if old_dep == module[0] and not streams:
+                        new_deps.add_buildtime_stream(module[0], module[1])
+                        added_build_deps.append(old_dep)
+
+        for old_dep in old_deps.get_buildtime_modules():
+            streams = old_deps.get_buildtime_streams(old_dep)
+            if old_dep not in added_build_deps:
+                for stream in streams:
+                    new_deps.add_buildtime_stream(old_dep, stream)
+
+        # Override runtime modules if needed
+        added_runtime_deps = []
+        for old_dep in old_deps.get_runtime_modules():
+            streams = old_deps.get_runtime_streams(old_dep)
+            for module in modules:
+                if old_dep == module[0] and not streams:
+                    new_deps.add_runtime_stream(module[0], module[1])
+                    added_runtime_deps.append(old_dep)
+
+        for old_dep in old_deps.get_runtime_modules():
+            streams = old_deps.get_runtime_streams(old_dep)
+            if old_dep not in added_runtime_deps:
+                for stream in streams:
+                    new_deps.add_runtime_stream(old_dep, stream)
+
+        self._stream.clear_dependencies()
+        self._stream.add_dependencies(new_deps)
+
     def get_build_deps(self) -> dict:
         build_deps = {}
         # try to extract a detailed requirements list from the

--- a/alws/utils/pulp_client.py
+++ b/alws/utils/pulp_client.py
@@ -32,18 +32,13 @@ class PulpClient:
             name, repo_href, base_path_start=distro_path_start)
         return distro, repo_href
 
-    async def create_build_rpm_repo(self, name: str) -> str:
-        ENDPOINT = 'pulp/api/v3/repositories/rpm/rpm/'
-        payload = {'name': name, 'autopublish': True,
-                   'retain_repo_versions': 1}
-        response = await self.make_post_request(ENDPOINT, data=payload)
-
     async def create_rpm_repository(
             self, name, auto_publish: bool = False,
             create_publication: bool = False,
             base_path_start: str = 'builds') -> (str, str):
         endpoint = 'pulp/api/v3/repositories/rpm/rpm/'
-        payload = {'name': name, 'autopublish': auto_publish}
+        payload = {'name': name, 'autopublish': auto_publish,
+                   'retain_repo_versions': 1}
         response = await self.make_post_request(endpoint, data=payload)
         repo_href = response['pulp_href']
         if create_publication:
@@ -359,7 +354,7 @@ class PulpClient:
             'repository_version': fse_repository_version
         }
         fse_task = await self.make_post_request(endpoint, params)
-        await pulp_client.wait_for_task(fse_task['task'])
+        await self.wait_for_task(fse_task['task'])
         return fse_repository_version
 
     async def get_repo_latest_version(self, repo_href: str):


### PR DESCRIPTION
This commit adds ability to set empty streams for build time and runtime
modules dependencies in modules.yaml file to correct ones from mock
options.