### PR TITLE
Albs 73 with repodata exporting

### DIFF
--- a/alws/crud/repo_exporter.py
+++ b/alws/crud/repo_exporter.py
@@ -54,8 +54,7 @@ async def create_pulp_exporters_to_fs(db: Session,
     for repo in response.scalars().all():
         export_path = str(Path(settings.pulp_export_path,
                                generate_repository_path(
-                                   export_task_pk, repo.name,
-                                   repo.arch, repo.debug)))
+                                   repo.name, repo.arch, repo.debug)))
         fs_exporter_href = await pulp_client.create_filesystem_exporter(
             repo.name, export_path)
         export_repos.append({

--- a/alws/routers/repositories.py
+++ b/alws/routers/repositories.py
@@ -49,11 +49,7 @@ async def fs_export_repository(repository_ids: list,
         res = await get_urls_from_html(repo_url)
         for url in res:
             dir_rd = Path(repo_elem).parent / 'repodata'
-            print(dir_rd)
-            try:
-                os.makedirs(dir_rd, exist_ok=True)
-            except Exception as e:
-                pass
+            os.makedirs(dir_rd, exist_ok=True)
             await download_file(url, dir_rd / Path(url).name)
     return export_paths
 

--- a/alws/routers/repositories.py
+++ b/alws/routers/repositories.py
@@ -1,5 +1,11 @@
+import os
 import typing
+import aiohttp
+import aiofiles
+import urllib
+from pathlib import Path
 
+from lxml.html import document_fromstring
 from fastapi import APIRouter, Depends
 
 from alws import database
@@ -35,6 +41,37 @@ async def fs_export_repository(repository_ids: list,
                                db: database.Session = Depends(get_db)):
     export_task = await repo_exporter.create_pulp_exporters_to_fs(
         db, repository_ids)
-    export_paths = await repo_exporter.execute_pulp_exporters_to_fs(
+    export_data = await repo_exporter.execute_pulp_exporters_to_fs(
         db, export_task)
+    export_paths = list(export_data.keys())
+    for repo_elem, repo_data in export_data.items():
+        repo_url = urllib.parse.urljoin(repo_data, 'repodata/')
+        res = await get_urls_from_html(repo_url)
+        for url in res:
+            dir_rd = Path(repo_elem).parent / 'repodata'
+            print(dir_rd)
+            try:
+                os.makedirs(dir_rd, exist_ok=True)
+            except Exception as e:
+                pass
+            await download_file(url, dir_rd / Path(url).name)
     return export_paths
+
+
+async def get_urls_from_html(base_url: str):
+    async with aiohttp.ClientSession() as session:
+        async with session.get(base_url) as response:
+            response.raise_for_status()
+            content = await response.text()
+            doc = document_fromstring(content)
+            children_urls = [base_url + a.get('href')
+                             for a in doc.xpath('//a')]
+            return children_urls
+
+
+async def download_file(url: str, dest: str):
+    async with aiohttp.ClientSession() as session:
+        async with session.get(url) as response:
+            content = await response.content.read()
+        async with aiofiles.open(dest, 'wb') as f:
+            await f.write(content)

--- a/alws/utils/pulp_client.py
+++ b/alws/utils/pulp_client.py
@@ -328,7 +328,7 @@ class PulpClient:
     async def update_filesystem_exporter(self, fse_pulp_href: str,
                                          fse_name: str,
                                          fse_path: str,
-                                         fse_method: str='symlink'):
+                                         fse_method: str='hardlink'):
         endpoint = fse_pulp_href
         params = {
             'name': fse_name,

--- a/alws/utils/pulp_client.py
+++ b/alws/utils/pulp_client.py
@@ -177,6 +177,7 @@ class PulpClient:
         await self.wait_for_task(task['task'])
 
     async def create_rpm_publication(self, repository: str):
+        # Creates repodata for repositories in some way
         ENDPOINT = 'pulp/api/v3/publications/rpm/rpm/'
         payload = {'repository': repository}
         task = await self.make_post_request(ENDPOINT, data=payload)

--- a/alws/utils/repository.py
+++ b/alws/utils/repository.py
@@ -7,5 +7,8 @@ __all__ = ['generate_repository_path']
 def generate_repository_path(export_id: int, repo_name: str,
                              arch: str, debug: bool) -> Path:
     if debug:
-        arch = f'{arch}-debug'
-    return Path(str(export_id), repo_name, arch)
+        return Path(str(export_id), repo_name, 'debug', arch, 'Packages')
+    elif arch == 'src':
+        return Path(str(export_id), repo_name, 'Source', 'Packages')
+    else:
+        return Path(str(export_id), repo_name, arch, 'Packages')

--- a/alws/utils/repository.py
+++ b/alws/utils/repository.py
@@ -4,11 +4,10 @@ from pathlib import Path
 __all__ = ['generate_repository_path']
 
 
-def generate_repository_path(export_id: int, repo_name: str,
-                             arch: str, debug: bool) -> Path:
+def generate_repository_path(repo_name: str, arch: str, debug: bool) -> Path:
     if debug:
-        return Path(str(export_id), repo_name, 'debug', arch, 'Packages')
+        return Path(repo_name, 'debug', arch, 'Packages')
     elif arch == 'src':
-        return Path(str(export_id), repo_name, 'Source', 'Packages')
+        return Path(repo_name, 'Source', 'Packages')
     else:
-        return Path(str(export_id), repo_name, arch, 'Packages')
+        return Path(repo_name, arch, 'Packages')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,7 @@ services:
     volumes:
       - "./alws:/code/alws"
       - "./scripts:/code/scripts"
+      - "./volumes/pulp/exports:/srv/exports"
       - "./reference_data:/code/reference_data"
     command:
         bash -c 'source env/bin/activate &&

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,11 +5,12 @@ psycopg2-binary==2.9.3
 pydantic==1.8.2
 SQLAlchemy==1.4.29
 aiohttp==3.8.1
+aiofiles==0.8.0
+aioredis==2.0.1
 PyJWT==2.3.0
 alembic==1.7.5
-aioredis==2.0.1
 pytest==6.2.5
 jmespath==0.10.0
-pytest==6.2.5
 PyYAML==5.4.1
+lxml==4.7.1
 syncer==1.3.0


### PR DESCRIPTION
Added a couple of libs. Also changed some volumes (web-server have to store repodata near exported repos by pulp). So the docker images albs-web-server_web_server_1 should be rebuilt.

For pulp config pulp/setting/setting.py we should use ALLOWED_EXPORT_PATHS=['/srv/exports'] line to allow exporting