### PR TITLE
Fixed build_done method. Improved reliability of task finish

### DIFF
--- a/alws/constants.py
+++ b/alws/constants.py
@@ -6,10 +6,11 @@ from collections import namedtuple
 
 __all__ = ['BuildTaskStatus', 'ReleaseStatus', 'TestTaskStatus',
            'BuildTaskRefType', 'SignStatus', 'RepoType', 'ExportStatus',
-           'debuginfo_regex', 'REQUEST_TIMEOUT']
+           'debuginfo_regex', 'REQUEST_TIMEOUT', 'DRAMATIQ_TASK_TIMEOUT']
 
 
 REQUEST_TIMEOUT = 60  # 1 minute
+DRAMATIQ_TASK_TIMEOUT = 3600000  # 1 hour in milliseconds
 
 
 class BuildTaskStatus(enum.IntEnum):

--- a/alws/crud/build_node.py
+++ b/alws/crud/build_node.py
@@ -219,7 +219,6 @@ async def __process_logs(pulp_client: PulpClient, task_id: int,
     hrefs = [item[0] for item in results]
     try:
         await pulp_client.modify_repository(repo.pulp_href, add=hrefs)
-        await pulp_client.create_file_publication(repo.pulp_href)
     except Exception as e:
         logging.error('Cannot add log files to the repository: %s',
                       str(e))

--- a/alws/crud/build_node.py
+++ b/alws/crud/build_node.py
@@ -135,7 +135,7 @@ async def __process_rpms(pulp_client: PulpClient, task_id: int, task_arch: str,
     for artifact in task_artifacts:
         if artifact.arch == 'src' and built_srpm_url is None:
             src_packages_tasks.append(create_entity(pulp_client, artifact))
-        if artifact.is_debuginfo:
+        elif artifact.is_debuginfo:
             debug_packages_tasks.append(create_entity(pulp_client, artifact))
         else:
             arch_packages_tasks.append(create_entity(pulp_client, artifact))

--- a/alws/crud/build_node.py
+++ b/alws/crud/build_node.py
@@ -220,8 +220,8 @@ async def __process_logs(pulp_client: PulpClient, task_id: int,
     try:
         await pulp_client.modify_repository(repo.pulp_href, add=hrefs)
     except Exception as e:
-        logging.error('Cannot add log files to the repository: %s',
-                      str(e))
+        logging.exception('Cannot add log files to the repository: %s',
+                          str(e))
         raise RepositoryAddError(
             'Cannot save build log into Pulp repository: %s', str(e))
     return logs
@@ -261,7 +261,7 @@ async def __process_build_task_artifacts(
             module_index = IndexWrapper.from_template(repo_modules_yaml)
         except Exception as e:
             message = f'Cannot parse modules index: {str(e)}'
-            logging.error('Cannot parse modules index: %s', str(e))
+            logging.exception('Cannot parse modules index: %s', str(e))
             raise ModuleUpdateError(message) from e
     rpm_artifacts = [item for item in task_artifacts if item.type == 'rpm']
     log_artifacts = [item for item in task_artifacts
@@ -302,8 +302,8 @@ async def __process_build_task_artifacts(
             build_task.rpm_module.pulp_href = module_pulp_href
         except Exception as e:
             message = f'Cannot update module information inside Pulp: {str(e)}'
-            logging.error('Cannot update module information inside Pulp: %s',
-                          str(e))
+            logging.exception('Cannot update module information inside Pulp: %s',
+                              str(e))
             raise ModuleUpdateError(message) from e
 
     db.add_all(rpm_entries)
@@ -419,7 +419,7 @@ async def build_done(
             if multilib_pkgs:
                 await add_multilib_packages(db, build_task, multilib_pkgs)
         except Exception as e:
-            logging.error('Cannot process multilib packages: %s', str(e))
+            logging.exception('Cannot process multilib packages: %s', str(e))
             raise MultilibProcessingError('Cannot process multilib packages')
 
     await db.execute(
@@ -430,7 +430,7 @@ async def build_done(
     try:
         await save_noarch_packages(db, build_task)
     except Exception as e:
-        logging.error('Cannot process noarch packages: %s', str(e))
+        logging.exception('Cannot process noarch packages: %s', str(e))
         raise NoarchProcessingError('Cannot process noarch packages')
 
     await db.execute(

--- a/alws/crud/distribution.py
+++ b/alws/crud/distribution.py
@@ -93,7 +93,8 @@ async def add_distributions_after_rebuild(
                              settings.pulp_password)
 
     for db_distro in db_distros:
-        modify = await prepare_repo_modify_dict(db_build, db_distro)
+        modify = await prepare_repo_modify_dict(
+            db_build, db_distro, pulp_client)
         for modification in ('remove', 'add'):
             for key, value in modify.items():
                 if modification == 'add':

--- a/alws/crud/distribution.py
+++ b/alws/crud/distribution.py
@@ -152,7 +152,7 @@ async def get_existing_packages(pulp_client: PulpClient,
 
 
 async def modify_distribution(build_id: int, distribution: str, db: Session,
-                              modification: str):
+                              modification: str, force: bool = False):
 
     async with db.begin():
         db_distro = await db.execute(select(models.Distribution).where(
@@ -172,12 +172,12 @@ async def modify_distribution(build_id: int, distribution: str, db: Session,
         ))
         db_build = db_build.scalars().first()
 
-        if modification == 'add':
+        if modification == 'add' and not force:
             if db_build in db_distro.builds:
                 error_msg = f'Packages of build {build_id} have already been' \
                             f' added to {distribution} distribution'
                 raise DistributionError(error_msg)
-        if modification == 'remove':
+        if modification == 'remove' and not force:
             if db_build not in db_distro.builds:
                 error_msg = f'Packages of build {build_id} cannot be removed ' \
                             f'from {distribution} distribution ' \

--- a/alws/crud/sign_task.py
+++ b/alws/crud/sign_task.py
@@ -221,6 +221,7 @@ async def complete_sign_task(db: Session, sign_task_id: int,
 
             for repo_href, packages in packages_to_add.items():
                 await pulp_client.modify_repository(repo_href, add=packages)
+                await pulp_client.create_rpm_publication(repo_href)
 
         if payload.success and not sign_failed:
             sign_task.status = SignStatus.COMPLETED

--- a/alws/crud/test.py
+++ b/alws/crud/test.py
@@ -1,3 +1,5 @@
+import asyncio
+import logging
 import re
 from collections import defaultdict
 from io import BytesIO
@@ -48,11 +50,7 @@ async def create_test_tasks(db: Session, build_task_id: int):
     )
     db.add(repository)
     await db.commit()
-
-    r_query = select(models.Repository).where(
-        models.Repository.name == repo_name)
-    results = await db.execute(r_query)
-    repository = results.scalars().first()
+    await db.refresh(repository)
 
     test_tasks = []
     for artifact in build_task.artifacts:
@@ -85,6 +83,11 @@ async def restart_build_tests(db: Session, build_id: int):
         await create_test_tasks(db, build_task_id[0])
 
 
+async def __convert_to_file(pulp_client: PulpClient, artifact: dict):
+    href = await pulp_client.create_file(artifact['name'], artifact['href'])
+    return artifact['name'], href
+
+
 async def complete_test_task(db: Session, task_id: int,
                              test_result: test_schema.TestTaskResult):
     pulp_client = PulpClient(
@@ -92,10 +95,26 @@ async def complete_test_task(db: Session, task_id: int,
         settings.pulp_user,
         settings.pulp_password
     )
+    logs = []
+    new_hrefs = []
+    conv_tasks = []
+    for log in test_result.result.get('logs', []):
+        if log.get('href'):
+            conv_tasks.append(__convert_to_file(pulp_client, log))
+        else:
+            logging.error('Log file %s is missing href', str(log))
+            continue
+    results = await asyncio.gather(*conv_tasks)
+    for name, href in results:
+        new_hrefs.append(href)
+        log_record = models.TestTaskArtifact(
+            name=name, href=href, test_task_id=task_id)
+        logs.append(log_record)
+
     async with db.begin():
         tasks = await db.execute(select(models.TestTask).where(
             models.TestTask.id == task_id).options(
-            selectinload(models.TestTask.repository)).with_for_update())
+            selectinload(models.TestTask.repository)))
         task = tasks.scalars().first()
         status = TestTaskStatus.COMPLETED
         for key, item in test_result.result.items():
@@ -112,28 +131,13 @@ async def complete_test_task(db: Session, task_id: int,
                 break
         task.status = status
         task.alts_response = test_result.dict()
-        logs = []
-        new_hrefs = []
-        for log in test_result.result.get('logs', []):
-            if task.repository:
-                href = await pulp_client.create_file(log['name'], log['href'])
-            else:
-                href = log['href']
-            if not href:
-                continue
-            new_hrefs.append(href)
-            log_record = models.TestTaskArtifact(
-                name=log['name'], href=href, test_task_id=task.id)
-            logs.append(log_record)
-        if task.repository:
-            await pulp_client.modify_repository(
-                task.repository.pulp_href, add=new_hrefs)
-            await pulp_client.create_file_publication(
-                task.repository.pulp_href)
+    if task.repository:
+        await pulp_client.modify_repository(
+            task.repository.pulp_href, add=new_hrefs)
 
-        db.add(task)
-        db.add_all(logs)
-        await db.commit()
+    db.add(task)
+    db.add_all(logs)
+    await db.commit()
 
 
 async def get_test_tasks_by_build_task(

--- a/alws/dramatiq/build.py
+++ b/alws/dramatiq/build.py
@@ -5,6 +5,7 @@ import dramatiq
 from sqlalchemy.future import select
 
 from alws import models
+from alws.constants import DRAMATIQ_TASK_TIMEOUT
 from alws.crud import build_node as build_node_crud, test
 from alws.errors import (
     ArtifactConversionError,
@@ -72,7 +73,7 @@ def start_build(build_id: int, build_request: Dict[str, Any]):
 @dramatiq.actor(
     max_retries=0,
     priority=1,
-    time_limit=3600000,
+    time_limit=DRAMATIQ_TASK_TIMEOUT,
     throws=(ArtifactConversionError, ModuleUpdateError,
             MultilibProcessingError, NoarchProcessingError,
             RepositoryAddError, SrpmProvisionError)

--- a/alws/dramatiq/build.py
+++ b/alws/dramatiq/build.py
@@ -6,6 +6,14 @@ from sqlalchemy.future import select
 
 from alws import models
 from alws.crud import build_node as build_node_crud, test
+from alws.errors import (
+    ArtifactConversionError,
+    ModuleUpdateError,
+    MultilibProcessingError,
+    NoarchProcessingError,
+    RepositoryAddError,
+    SrpmProvisionError,
+)
 from alws.build_planner import BuildPlanner
 from alws.schemas import build_schema, build_node_schema
 from alws.database import SyncSession
@@ -63,7 +71,11 @@ def start_build(build_id: int, build_request: Dict[str, Any]):
 
 @dramatiq.actor(
     max_retries=0,
-    priority=1
+    priority=1,
+    time_limit=3600000,
+    throws=(ArtifactConversionError, ModuleUpdateError,
+            MultilibProcessingError, NoarchProcessingError,
+            RepositoryAddError, SrpmProvisionError)
 )
 def build_done(request: Dict[str, Any]):
     parsed_build = build_node_schema.BuildDone(**request)

--- a/alws/dramatiq/sign_task.py
+++ b/alws/dramatiq/sign_task.py
@@ -3,6 +3,7 @@ import typing
 import dramatiq
 
 from alws.crud import sign_task
+from alws.constants import DRAMATIQ_TASK_TIMEOUT
 from alws.dependencies import get_db
 from alws.dramatiq import event_loop
 from alws.schemas import sign_schema
@@ -18,8 +19,8 @@ async def _complete_sign_task(
             db, task_id, sign_schema.SignTaskComplete(**payload))
 
 
-# Timeout for the task is set to 1 hour in miliseconds. This is needed
+# Timeout for the task is set to 1 hour in milliseconds. This is needed
 # to process large jobs with a lot of RPM packages inside
-@dramatiq.actor(max_retries=2, priority=1, time_limit=3600000)
+@dramatiq.actor(max_retries=2, priority=1, time_limit=DRAMATIQ_TASK_TIMEOUT)
 def complete_sign_task(task_id: int, payload: typing.Dict[str, typing.Any]):
     event_loop.run_until_complete(_complete_sign_task(task_id, payload))

--- a/alws/errors.py
+++ b/alws/errors.py
@@ -36,3 +36,27 @@ class SignKeyAlreadyExistsError(ValueError):
 
 class BuildAlreadySignedError(ValueError):
     pass
+
+
+class ArtifactConversionError(Exception):
+    pass
+
+
+class SrpmProvisionError(Exception):
+    pass
+
+
+class MultilibProcessingError(Exception):
+    pass
+
+
+class NoarchProcessingError(Exception):
+    pass
+
+
+class ModuleUpdateError(Exception):
+    pass
+
+
+class RepositoryAddError(Exception):
+    pass

--- a/alws/models.py
+++ b/alws/models.py
@@ -359,6 +359,11 @@ class RpmModule(Base):
     pulp_href = sqlalchemy.Column(sqlalchemy.TEXT, nullable=False)
     sha256 = sqlalchemy.Column(sqlalchemy.VARCHAR(64), nullable=False)
 
+    @property
+    def nvsca(self):
+        return (f'{self.name}-{self.version}-{self.stream}'
+                f'-{self.context}-{self.arch}')
+
 
 class BuildTaskArtifact(Base):
 

--- a/alws/utils/ids.py
+++ b/alws/utils/ids.py
@@ -1,0 +1,9 @@
+import random
+import time
+
+
+__all__ = ['get_random_unique_version']
+
+
+def get_random_unique_version():
+    return int(str(int(time.time())) + str(random.randint(1000000, 9999999)))

--- a/alws/utils/modularity.py
+++ b/alws/utils/modularity.py
@@ -1,7 +1,5 @@
 import re
 import json
-import time
-import random
 import typing
 import hashlib
 import datetime
@@ -13,10 +11,6 @@ from pydantic import BaseModel
 import gi
 gi.require_version('Modulemd', '2.0')
 from gi.repository import Modulemd
-
-
-def get_random_unique_version():
-    return int(str(int(time.time())) + str(random.randint(1000000, 9999999)))
 
 
 def calc_dist_macro(

--- a/alws/utils/pulp_client.py
+++ b/alws/utils/pulp_client.py
@@ -348,7 +348,7 @@ class PulpClient:
             include_fields: typing.List[str] = None,
             exclude_fields: typing.List[str] = None,
             **search_params):
-        latest_version = self.get_repo_latest_version(repository_href)
+        latest_version = await self.get_repo_latest_version(repository_href)
         params = {'repository_version': latest_version, 'limit': 1000}
         params.update(**search_params)
         return await self.get_rpm_packages(

--- a/alws/utils/pulp_client.py
+++ b/alws/utils/pulp_client.py
@@ -497,7 +497,7 @@ class PulpClient:
     async def wait_for_task(self, task_href: str):
         task = await self.request('GET', task_href)
         while task['state'] not in ('failed', 'completed'):
-            await asyncio.sleep(1)
+            await asyncio.sleep(2)
             task = await self.request('GET', task_href)
         if task['state'] == 'failed':
             raise Exception(f'Task {str(task)} has failed')

--- a/alws/utils/pulp_client.py
+++ b/alws/utils/pulp_client.py
@@ -25,7 +25,7 @@ class PulpClient:
     async def create_log_repo(
             self, name: str, distro_path_start: str = 'build_logs') -> (str, str):
         ENDPOINT = 'pulp/api/v3/repositories/file/file/'
-        payload = {'name': name, 'autopublish': True}
+        payload = {'name': name, 'autopublish': False}
         response = await self.request('POST', ENDPOINT, json=payload)
         repo_href = response['pulp_href']
         await self.create_file_publication(repo_href)

--- a/alws/utils/pulp_client.py
+++ b/alws/utils/pulp_client.py
@@ -349,7 +349,7 @@ class PulpClient:
             exclude_fields: typing.List[str] = None,
             **search_params):
         latest_version = await self.get_repo_latest_version(repository_href)
-        params = {'repository_version': latest_version, 'limit': 1000}
+        params = {'repository_version': latest_version, 'limit': 10000}
         params.update(**search_params)
         return await self.get_rpm_packages(
             include_fields=include_fields, exclude_fields=exclude_fields,

--- a/alws/utils/pulp_client.py
+++ b/alws/utils/pulp_client.py
@@ -8,7 +8,7 @@ from typing import List
 import aiohttp
 
 from alws.utils.file_utils import hash_content
-from alws.utils.modularity import get_random_unique_version
+from alws.utils.ids import get_random_unique_version
 
 
 PULP_SEMAPHORE = asyncio.Semaphore(10)

--- a/alws/utils/uploader.py
+++ b/alws/utils/uploader.py
@@ -4,10 +4,8 @@ import typing
 import urllib.parse
 
 from alws.config import settings
-from alws.utils.modularity import (
-    IndexWrapper,
-    get_random_unique_version,
-)
+from alws.utils.ids import get_random_unique_version 
+from alws.utils.modularity import IndexWrapper
 from alws.utils.pulp_client import PulpClient
 
 


### PR DESCRIPTION
This commit brings several things to make `build_done` endpoint more reliable:
1. Separate exceptions for different things: help react on a particular error;
2. Increased timeout for the `build_done` dramatiq actor;
3. Reworked build artifacts processing: now packages are added to the repository only when all of them were converted from artifacts to actual RPM packages;
4. Improved logs handling: logs are processed similarly to packages, but now they are first in line and committed separately from packages;
5. Modules errors handling: both parsing initial data and adding new artifacts.