### PR TITLE
Fix 404 on repodata/packages while build is in progress

### DIFF
--- a/alws/utils/pulp_client.py
+++ b/alws/utils/pulp_client.py
@@ -40,8 +40,11 @@ class PulpClient:
             create_publication: bool = False,
             base_path_start: str = 'builds') -> (str, str):
         endpoint = 'pulp/api/v3/repositories/rpm/rpm/'
-        payload = {'name': name, 'autopublish': auto_publish,
-                   'retain_repo_versions': 1}
+        payload = {
+            'name': name,
+            'autopublish': auto_publish,
+            'retain_repo_versions': 5,
+        }
         response = await self.request('POST', endpoint, json=payload)
         repo_href = response['pulp_href']
         if create_publication:


### PR DESCRIPTION
This is sequence in which pulp retain old repo versions / creates new one:
```
pulpcore.app.models.repository:INFO: Deleting repository version <Repository: AlmaLinux-9-i686-19-br; Version: 7> due to version retention limit.
pulp_rpm.app.tasks.publishing:INFO: Publishing: repository=AlmaLinux-9-i686-19-br, version=8
pulp_rpm.app.tasks.publishing:INFO: Publication: f87e0429-aef3-4cb7-8c95-ab6bdaa19e34 created
```
As you can see, if you have only 1 version in your repository, there is a point in time, in which there is 0 publications for given repository, which cause 404 errors on our builds pipeline