### PR TITLE
ALBS-388: Ensure that per-project mock_options are taken into account

### DIFF
--- a/alws/build_planner.py
+++ b/alws/build_planner.py
@@ -221,7 +221,7 @@ class BuildPlanner:
                 url=task.url,
                 git_ref=task.git_ref,
                 ref_type=task.ref_type
-            ))
+            ), mock_options=task.mock_options)
             return
 
         if isinstance(task, build_schema.BuildTaskModuleRef):

--- a/alws/schemas/build_schema.py
+++ b/alws/schemas/build_schema.py
@@ -33,6 +33,7 @@ class BuildTaskRef(BaseModel):
     url: str
     git_ref: typing.Optional[str]
     ref_type: typing.Optional[int]
+    mock_options: typing.Optional[typing.Dict[str, typing.Any]]
     is_module: typing.Optional[bool] = False
     enabled: bool = True
     added_artifacts: typing.Optional[list] = []
@@ -160,6 +161,7 @@ class BuildTask(BaseModel):
     ref: BuildTaskRef
     rpm_module: typing.Optional[RpmModule]
     artifacts: typing.List[BuildTaskArtifact]
+    mock_options: typing.Optional[typing.Dict[str, typing.Any]]
     is_secure_boot: typing.Optional[bool]
     test_tasks: typing.List[BuildTaskTestTask]
     error: typing.Optional[str]


### PR DESCRIPTION
Now the per-project mock options are taken into account

![image](https://user-images.githubusercontent.com/821790/175087512-00d6d70a-6ca9-42ff-bac0-40bbf5bc0323.png)

![image](https://user-images.githubusercontent.com/821790/175087740-2a3bff2a-1c00-48dc-8f6e-ed8125da509d.png)
