### PR TITLE
Use correct link to beta repository for s390x

### DIFF
--- a/reference_data/platforms.yaml
+++ b/reference_data/platforms.yaml
@@ -977,7 +977,7 @@
     - arch: s390x
       name: almalinux-8-beta-s390x
       type: rpm
-      remote_url: https://build.almalinux.org/pulp/content/builds/almalinux8-s390x-beta-AlmaLinux-8-s390x-dr/
+      remote_url: https://build.almalinux.org/pulp/content/builds/almalinux-8-beta-s390x-AlmaLinux-8-s390x-dr/
       production: false
       priority: 10
       debug: false


### PR DESCRIPTION
Hello, I mistake, when I was creating a beta repository for s390x, so we need to change the link to this repository