### PR TITLE
ALBS-607: Search doesn't work with some names

### DIFF
--- a/alws/alembic/versions/26b384d34941_albs_607_fill_empty_non_nullable_builds_fields.py
+++ b/alws/alembic/versions/26b384d34941_albs_607_fill_empty_non_nullable_builds_fields.py
@@ -1,0 +1,23 @@
+"""Removed Distributions
+
+Revision ID: 26b384d34941
+Revises: 26b384d3493f
+Create Date: 2022-09-01 10:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "26b384d34941"
+down_revision = "26b384d3493f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(sa.text("UPDATE builds SET released = false WHERE released is NULL"))
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
- Some records from db table `builds` have nullable field `released`, but pydentic model Build
  has the same field as not-nullable and required.
  It's prepared db migration which set the field to False for all records there is the field is null.