### PR TITLE
Update beta flavors and remove beta repos from AlmaLinux 9 stable

### DIFF
--- a/reference_data/platform_flavors.yaml
+++ b/reference_data/platform_flavors.yaml
@@ -4,15 +4,14 @@
       modified: a8-beta
       non_modified: c8-beta
     versions:
-      - name: '8.6'
-        version_prefix: '80600'
-        dist_prefix: 'el8.6.0'
+      - name: '8.7'
+        version_prefix: '80700'
+        dist_prefix: 'el8.7.0'
   repositories:
     - name: almalinux-8-beta
       arch: i686
       type: rpm
       remote_url: https://build.almalinux.org/pulp/content/builds/almalinux8-beta-AlmaLinux-8-i686-dr/
-      export_path: almalinux/8.6-beta/i686/
       production: false
       debug: false
       priority: 5
@@ -20,7 +19,6 @@
       arch: x86_64
       type: rpm
       remote_url: https://build.almalinux.org/pulp/content/builds/almalinux8-beta-AlmaLinux-8-x86_64-dr/
-      export_path: almalinux/8.6-beta/x86_64/
       production: false
       debug: false
       priority: 5
@@ -28,7 +26,6 @@
       arch: aarch64
       type: rpm
       remote_url: https://build.almalinux.org/pulp/content/builds/almalinux8-beta-AlmaLinux-8-aarch64-dr/
-      export_path: almalinux/8.6-beta/aarch64/
       production: false
       debug: false
       priority: 5
@@ -36,7 +33,13 @@
       arch: ppc64le
       type: rpm
       remote_url: https://build.almalinux.org/pulp/content/builds/almalinux8-beta-AlmaLinux-8-ppc64le-dr/
-      export_path: almalinux/8.6-beta/ppc64le/
+      production: false
+      debug: false
+      priority: 5
+    - name: almalinux-8-beta
+      arch: s390x
+      type: rpm
+      remote_url: https://build.almalinux.org/pulp/content/builds/almalinux8-beta-AlmaLinux-8-s390x-dr/
       production: false
       debug: false
       priority: 5
@@ -44,7 +47,6 @@
       arch: i686
       type: rpm
       remote_url: https://build.almalinux.org/pulp/content/builds/almalinux8-beta-AlmaLinux-8-i686-debug-dr/
-      export_path: almalinux/8.6-beta/debug/i686/
       production: false
       debug: true
       priority: 5
@@ -52,7 +54,6 @@
       arch: x86_64
       type: rpm
       remote_url: https://build.almalinux.org/pulp/content/builds/almalinux8-beta-AlmaLinux-8-x86_64-debug-dr/
-      export_path: almalinux/8.6-beta/debug/x86_64/
       production: false
       debug: true
       priority: 5
@@ -60,7 +61,6 @@
       arch: aarch64
       type: rpm
       remote_url: https://build.almalinux.org/pulp/content/builds/almalinux8-beta-AlmaLinux-8-aarch64-debug-dr/
-      export_path: almalinux/8.6-beta/debug/aarch64/
       production: false
       debug: true
       priority: 5
@@ -68,7 +68,13 @@
       arch: ppc64le
       type: rpm
       remote_url: https://build.almalinux.org/pulp/content/builds/almalinux8-beta-AlmaLinux-8-ppc64le-debug-dr/
-      export_path: almalinux/8.6-beta/debug/ppc64le/
+      production: false
+      debug: true
+      priority: 5
+    - name: almalinux-8-beta-debuginfo
+      arch: s390x
+      type: rpm
+      remote_url: https://build.almalinux.org/pulp/content/builds/almalinux8-beta-AlmaLinux-8-s390x-debug-dr/
       production: false
       debug: true
       priority: 5
@@ -76,12 +82,99 @@
       arch: src
       type: rpm
       remote_url: https://build.almalinux.org/pulp/content/builds/almalinux8-beta-AlmaLinux-8-src-dr/
-      export_path: almalinux/8.6-beta/source/
       production: false
       debug: false
       priority: 5
 
-- name: Epel
+- name: AlmaLinux-9-beta
+  modularity:
+    git_tag_prefix:
+      modified: a9-beta
+      non_modified: c9-beta
+    versions:
+      - name: '9.1'
+        version_prefix: '90100'
+        dist_prefix: 'el9.1.0'
+  repositories:
+    - name: almalinux-9-beta
+      arch: i686
+      type: rpm
+      remote_url: https://build.almalinux.org/pulp/content/builds/AlmaLinux-9-beta-AlmaLinux-9-i686-dr/
+      production: false
+      debug: false
+      priority: 5
+    - name: almalinux-9-beta
+      arch: x86_64
+      type: rpm
+      remote_url: https://build.almalinux.org/pulp/content/builds/AlmaLinux-9-beta-AlmaLinux-9-x86_64-dr/
+      production: false
+      debug: false
+      priority: 5
+    - name: almalinux-9-beta
+      arch: aarch64
+      type: rpm
+      remote_url: https://build.almalinux.org/pulp/content/builds/AlmaLinux-9-beta-AlmaLinux-9-aarch64-dr/
+      production: false
+      debug: false
+      priority: 5
+    - name: almalinux-9-beta
+      arch: ppc64le
+      type: rpm
+      remote_url: https://build.almalinux.org/pulp/content/builds/AlmaLinux-9-beta-AlmaLinux-9-ppc64le-dr/
+      production: false
+      debug: false
+      priority: 5
+    - name: almalinux-9-beta
+      arch: s390x
+      type: rpm
+      remote_url: https://build.almalinux.org/pulp/content/builds/AlmaLinux-9-beta-AlmaLinux-9-s390x-dr/
+      production: false
+      debug: false
+      priority: 5
+    - name: almalinux-9-beta-debuginfo
+      arch: i686
+      type: rpm
+      remote_url: https://build.almalinux.org/pulp/content/builds/AlmaLinux-9-beta-AlmaLinux-9-i686-debug-dr/
+      production: false
+      debug: true
+      priority: 5
+    - name: almalinux-9-beta-debuginfo
+      arch: x86_64
+      type: rpm
+      remote_url: https://build.almalinux.org/pulp/content/builds/AlmaLinux-9-beta-AlmaLinux-9-x86_64-debug-dr/
+      production: false
+      debug: true
+      priority: 5
+    - name: almalinux-9-beta-debuginfo
+      arch: aarch64
+      type: rpm
+      remote_url: https://build.almalinux.org/pulp/content/builds/AlmaLinux-9-beta-AlmaLinux-9-aarch64-debug-dr/
+      production: false
+      debug: true
+      priority: 5
+    - name: almalinux-9-beta-debuginfo
+      arch: ppc64le
+      type: rpm
+      remote_url: https://build.almalinux.org/pulp/content/builds/AlmaLinux-9-beta-AlmaLinux-9-ppc64le-debug-dr/
+      production: false
+      debug: true
+      priority: 5
+    - name: almalinux-9-beta-debuginfo
+      arch: s390x
+      type: rpm
+      remote_url: https://build.almalinux.org/pulp/content/builds/AlmaLinux-9-beta-AlmaLinux-9-s390x-debug-dr/
+      production: false
+      debug: true
+      priority: 5
+    - name: almalinux-9-beta
+      arch: src
+      type: rpm
+      remote_url: https://build.almalinux.org/pulp/content/builds/AlmaLinux-9-beta-AlmaLinux-9-src-dr/
+      production: false
+      debug: false
+      priority: 5
+
+- name: EPEL
   repositories:
     - name: epel
       arch: x86_64

--- a/reference_data/platforms.yaml
+++ b/reference_data/platforms.yaml
@@ -1298,41 +1298,6 @@
       repository_sync_policy: additive
       priority: 10
     - arch: i686
-      name: alma9-distribution-i686
-      remote_url: https://build.almalinux.org/pulp/content/builds/AlmaLinux-9-beta-AlmaLinux-9-i686-dr/
-      type: rpm
-      production: false
-      debug: false
-      priority: 10
-    - arch: x86_64
-      name: alma9-distribution-x86_64
-      remote_url: https://build.almalinux.org/pulp/content/builds/AlmaLinux-9-beta-AlmaLinux-9-x86_64-dr/
-      type: rpm
-      production: false
-      debug: false
-      priority: 10
-    - arch: aarch64
-      name: alma9-distribution-aarch64
-      remote_url: https://build.almalinux.org/pulp/content/builds/AlmaLinux-9-beta-AlmaLinux-9-aarch64-dr/
-      type: rpm
-      production: false
-      debug: false
-      priority: 10
-    - arch: ppc64le
-      name: alma9-distribution-ppc64le
-      remote_url: https://build.almalinux.org/pulp/content/builds/AlmaLinux-9-beta-AlmaLinux-9-ppc64le-dr/
-      type: rpm
-      production: false
-      debug: false
-      priority: 10
-    - arch: s390x
-      name: alma9-distribution-s390x
-      remote_url: https://build.almalinux.org/pulp/content/builds/AlmaLinux-9-beta-AlmaLinux-9-s390x-dr/
-      type: rpm
-      production: false
-      debug: false
-      priority: 10
-    - arch: i686
       name: almalinux-9-appstream
       type: rpm
       remote_url: http://rsync.repo.almalinux.org/vault/9/AppStream/i686/os/


### PR DESCRIPTION
- Add AlmaLinux-9-beta flavor for 9.1 Beta
- Update AlmaLinux-8-beta flavor for 8.7 Beta
- Remove beta repos from AlmaLinux 9 stable platform
- Use EPEL flavor name instead of Epel