### PR TITLE
ALBS-546: asio.src placed to mariadb module but should be in mariadb-devel

### DIFF
--- a/alws/crud/build_node.py
+++ b/alws/crud/build_node.py
@@ -303,18 +303,12 @@ async def __process_rpms(db: Session, pulp_client: PulpClient, task_id: int,
         logging.info('RPM package: %s', json.dumps(rpm_package, indent=4))
         logging.info('Packages info: %s', json.dumps(packages_info, indent=4))
         logging.info('Module: %s is devel: %s', module.name, module.is_devel)
-        if rpm_package['rpm_sourcerpm']:
+        if rpm_package['arch'] != 'src':
             # sRPM has that field empty
             return True
-        if not module.is_devel and any(
+        return not module.is_devel and any(
             package_info['rpm_sourcerpm'] == rpm_package['location_href'] and not module.is_artifact_filtered(package_info) for package_info in packages_info.values()
-        ):
-            return True
-        if module.is_devel and not all(
-            package_info['rpm_sourcerpm'] != rpm_package['location_href'] and not module.is_artifact_filtered(package_info) for package_info in packages_info.values()
-        ):
-            return True
-        return False
+        )
 
     if module_index and rpms:
         logging.info('RPMs: %s', rpms)

--- a/alws/crud/build_node.py
+++ b/alws/crud/build_node.py
@@ -305,12 +305,12 @@ async def __process_rpms(db: Session, pulp_client: PulpClient, task_id: int,
         if rpm_package['rpm_sourcerpm']:
             # sRPM has that field empty
             return True
-        if module.is_devel and all(
-            package_info['rpm_sourcerpm'] != rpm_package['location_href'] for package_info in packages_info.values()
+        if not module.is_devel and any(
+            package_info['rpm_sourcerpm'] == rpm_package['location_href'] and not module.is_artifact_filtered(packages_info) for package_info in packages_info.values()
         ):
             return True
-        if not module.is_devel and any(
-            package_info['rpm_sourcerpm'] == rpm_package['location_href'] for package_info in packages_info.values()
+        if module.is_devel and not any(
+            package_info['rpm_sourcerpm'] == rpm_package['location_href'] and not module.is_artifact_filtered(packages_info) for package_info in packages_info.values()
         ):
             return True
         return False

--- a/alws/crud/build_node.py
+++ b/alws/crud/build_node.py
@@ -300,8 +300,8 @@ async def __process_rpms(db: Session, pulp_client: PulpClient, task_id: int,
         rpms.append(artifact)
 
     def _is_srpm_filtered(srpm_info: dict, packages_info: dict, module: ModuleWrapper) -> bool:
-        logging.debug('SRPM info: %s', json.dumps(srpm_info, indent=4))
-        logging.debug('Packages info: %s', json.dumps(packages_info, indent=4))
+        logging.info('SRPM info: %s', json.dumps(srpm_info, indent=4))
+        logging.info('Packages info: %s', json.dumps(packages_info, indent=4))
         if not srpm_info:
             return False
         if module.is_devel and all(

--- a/alws/crud/build_node.py
+++ b/alws/crud/build_node.py
@@ -319,6 +319,7 @@ async def __process_rpms(db: Session, pulp_client: PulpClient, task_id: int,
             return True
         if module.is_devel and rpm_package['location_href'] not in srpms_dict:
             return True
+        return False
 
     if module_index and rpms:
         logging.info('RPMs: %s', rpms)
@@ -350,7 +351,9 @@ async def __process_rpms(db: Session, pulp_client: PulpClient, task_id: int,
                 for rpm in rpms:
                     rpm_package = packages_info[rpm.href]
                     if _is_srpm_included(rpm_package, packages_info, module):
-                        module.add_rpm_artifact(rpm_package)
+                        logging.info('RPM will be added: %s', rpm_package)
+                        logging.info('RPM is added: %s',
+                                     module.add_rpm_artifact(rpm_package))
                 if srpm_info:
                     module.add_rpm_artifact(srpm_info)
         except Exception as e:

--- a/alws/crud/build_node.py
+++ b/alws/crud/build_node.py
@@ -350,10 +350,13 @@ async def __process_rpms(db: Session, pulp_client: PulpClient, task_id: int,
             for module in module_index.iter_modules():
                 for rpm in rpms:
                     rpm_package = packages_info[rpm.href]
-                    if _is_srpm_included(rpm_package, packages_info, module):
+                    if _is_included := is_srpm_included(rpm_package, packages_info, module):
                         logging.info('RPM will be added: %s', rpm_package)
                         logging.info('RPM is added: %s',
-                                     module.add_rpm_artifact(rpm_package))
+                                     module.add_rpm_artifact(
+                                         rpm_package,
+                                         devel=_is_included and module.is_devel
+                                     ))
                 if srpm_info:
                     module.add_rpm_artifact(srpm_info)
         except Exception as e:

--- a/alws/crud/build_node.py
+++ b/alws/crud/build_node.py
@@ -29,9 +29,6 @@ from alws.utils.pulp_client import PulpClient
 from alws.utils.rpm_package import get_rpm_package_info
 
 
-logging.basicConfig(level=logging.DEBUG)
-
-
 async def get_available_build_task(
             db: Session,
             request: build_node_schema.RequestTask

--- a/alws/crud/build_node.py
+++ b/alws/crud/build_node.py
@@ -302,6 +302,7 @@ async def __process_rpms(db: Session, pulp_client: PulpClient, task_id: int,
     def _is_srpm_included(rpm_package: dict, packages_info: dict, module: ModuleWrapper) -> bool:
         logging.info('RPM package: %s', json.dumps(rpm_package, indent=4))
         logging.info('Packages info: %s', json.dumps(packages_info, indent=4))
+        logging.info('Module: %s is devel: %s', module.name, module.is_devel)
         if rpm_package['rpm_sourcerpm']:
             # sRPM has that field empty
             return True

--- a/alws/crud/build_node.py
+++ b/alws/crud/build_node.py
@@ -317,6 +317,7 @@ async def __process_rpms(db: Session, pulp_client: PulpClient, task_id: int,
         return False
 
     if module_index and rpms:
+        logging.info('RPMs: %s', rpms)
         pkg_fields = [
             'epoch',
             'name',

--- a/alws/crud/build_node.py
+++ b/alws/crud/build_node.py
@@ -300,7 +300,7 @@ async def __process_rpms(db: Session, pulp_client: PulpClient, task_id: int,
             )
         rpms.append(artifact)
 
-    def _is_srpm_included(rpm_package: dict, packages_info: dict, module: ModuleWrapper) -> bool:
+    def is_srpm_included(rpm_package: dict, packages_info: dict, module: ModuleWrapper) -> bool:
         logging.info('Module: %s is devel: %s', module.name, module.is_devel)
         logging.info('RPM package: %s', json.dumps(rpm_package, indent=4))
         logging.info('Packages info: %s', json.dumps(packages_info, indent=4))
@@ -350,7 +350,8 @@ async def __process_rpms(db: Session, pulp_client: PulpClient, task_id: int,
             for module in module_index.iter_modules():
                 for rpm in rpms:
                     rpm_package = packages_info[rpm.href]
-                    if _is_included := is_srpm_included(rpm_package, packages_info, module):
+                    if _is_included := is_srpm_included(rpm_package,
+                                                        packages_info, module):
                         logging.info('RPM will be added: %s', rpm_package)
                         logging.info('RPM is added: %s',
                                      module.add_rpm_artifact(

--- a/alws/crud/build_node.py
+++ b/alws/crud/build_node.py
@@ -306,11 +306,11 @@ async def __process_rpms(db: Session, pulp_client: PulpClient, task_id: int,
             # sRPM has that field empty
             return True
         if module.is_devel and all(
-            package_info['rpm_sourcerpm'] != rpm_package['location_href'] for package_info in packages_info
+            package_info['rpm_sourcerpm'] != rpm_package['location_href'] for package_info in packages_info.values()
         ):
             return True
         if not module.is_devel and any(
-            package_info['rpm_sourcerpm'] == rpm_package['location_href'] for package_info in packages_info
+            package_info['rpm_sourcerpm'] == rpm_package['location_href'] for package_info in packages_info.values()
         ):
             return True
         return False

--- a/alws/crud/build_node.py
+++ b/alws/crud/build_node.py
@@ -306,11 +306,11 @@ async def __process_rpms(db: Session, pulp_client: PulpClient, task_id: int,
             # sRPM has that field empty
             return True
         if not module.is_devel and any(
-            package_info['rpm_sourcerpm'] == rpm_package['location_href'] and not module.is_artifact_filtered(packages_info) for package_info in packages_info.values()
+            package_info['rpm_sourcerpm'] == rpm_package['location_href'] and not module.is_artifact_filtered(package_info) for package_info in packages_info.values()
         ):
             return True
         if module.is_devel and not any(
-            package_info['rpm_sourcerpm'] == rpm_package['location_href'] and not module.is_artifact_filtered(packages_info) for package_info in packages_info.values()
+            package_info['rpm_sourcerpm'] == rpm_package['location_href'] and not module.is_artifact_filtered(package_info) for package_info in packages_info.values()
         ):
             return True
         return False

--- a/alws/crud/build_node.py
+++ b/alws/crud/build_node.py
@@ -301,16 +301,20 @@ async def __process_rpms(db: Session, pulp_client: PulpClient, task_id: int,
         rpms.append(artifact)
 
     def _is_srpm_included(rpm_package: dict, packages_info: dict, module: ModuleWrapper) -> bool:
+        logging.info('Module: %s is devel: %s', module.name, module.is_devel)
         logging.info('RPM package: %s', json.dumps(rpm_package, indent=4))
         logging.info('Packages info: %s', json.dumps(packages_info, indent=4))
-        logging.info('Module: %s is devel: %s', module.name, module.is_devel)
         srpms_dict = defaultdict(list)
         for package_info in packages_info.values():
             if not module.is_artifact_filtered(package_info):
+                logging.info('Key: %s', package_info['rpm_sourcerpm'])
+                logging.info('Value: %s', package_info)
                 srpms_dict[package_info['rpm_sourcerpm']].append(package_info)
         if rpm_package['arch'] != 'src':
             # sRPM has that field empty
             return True
+        logging.info('RPMs arch: %s', rpm_package['arch'])
+        logging.info('RPM in sRPMs dict: %s', rpm_package['location_href'] in srpms_dict)
         if not module.is_devel and rpm_package['location_href'] in srpms_dict:
             return True
         if module.is_devel and rpm_package['location_href'] not in srpms_dict:

--- a/alws/crud/build_node.py
+++ b/alws/crud/build_node.py
@@ -309,8 +309,8 @@ async def __process_rpms(db: Session, pulp_client: PulpClient, task_id: int,
             package_info['rpm_sourcerpm'] == rpm_package['location_href'] and not module.is_artifact_filtered(package_info) for package_info in packages_info.values()
         ):
             return True
-        if module.is_devel and not any(
-            package_info['rpm_sourcerpm'] == rpm_package['location_href'] and not module.is_artifact_filtered(package_info) for package_info in packages_info.values()
+        if module.is_devel and not all(
+            package_info['rpm_sourcerpm'] != rpm_package['location_href'] and not module.is_artifact_filtered(package_info) for package_info in packages_info.values()
         ):
             return True
         return False

--- a/alws/crud/build_node.py
+++ b/alws/crud/build_node.py
@@ -348,8 +348,6 @@ async def __process_rpms(db: Session, pulp_client: PulpClient, task_id: int,
                 srpm_info = await pulp_client.get_rpm_package(
                     db_srpm.href, include_fields=pkg_fields)
         try:
-            logging.info('SRPM info: %s', json.dumps(srpm_info, indent=4))
-            logging.info('Packages info: %s', json.dumps(packages_info, indent=4))
             for module in module_index.iter_modules():
                 for rpm in rpms:
                     rpm_package = packages_info[rpm.href]

--- a/alws/crud/build_node.py
+++ b/alws/crud/build_node.py
@@ -29,6 +29,9 @@ from alws.utils.pulp_client import PulpClient
 from alws.utils.rpm_package import get_rpm_package_info
 
 
+logging.basicConfig(level=logging.DEBUG)
+
+
 async def get_available_build_task(
             db: Session,
             request: build_node_schema.RequestTask
@@ -337,6 +340,8 @@ async def __process_rpms(db: Session, pulp_client: PulpClient, task_id: int,
                 srpm_info = await pulp_client.get_rpm_package(
                     db_srpm.href, include_fields=pkg_fields)
         try:
+            logging.info('SRPM info: %s', json.dumps(srpm_info, indent=4))
+            logging.info('Packages info: %s', json.dumps(packages_info, indent=4))
             for module in module_index.iter_modules():
                 for rpm in rpms:
                     rpm_package = packages_info[rpm.href]


### PR DESCRIPTION
- We should add a source RPM into a non-devel module if a source RPM produced
   at least one RPM. Otherwise, we should add that source RPM into a devel module.