### PR TITLE
Pulp exporter improvements

### DIFF
--- a/alws/utils/errata.py
+++ b/alws/utils/errata.py
@@ -127,9 +127,9 @@ def debrand_comment(comment: str, distro_version: str) -> str:
 def find_metadata(repodata_dir, key) -> str:
     repomd = cr.Repomd(os.path.join(repodata_dir, 'repomd.xml'))
     path = next(
-        item.location_href
-        for item in repomd.records
-        if item.type == key
+        (item.location_href
+         for item in repomd.records
+         if item.type == key), None
     )
     return os.path.join(repodata_dir, os.path.basename(path))
 


### PR DESCRIPTION
- Fixed 400 error when starting the exporter;
- Re-using existing exporters instead of deleting/creating them from scratch;
- Cache repodata after re-generation to production-like mode;
- Cache packages checksums via `createrepo_c`;
- Allowed for parallel export of AlmaLinux 8 and 9;

Repodata and checksums caching as well as re-use of existing exporters allowed to reduce export time significantly.
Previously export took 1-1.5 hours depending on Pulp host load. Now it takes 15-20 minutes.