### PR TITLE
ALBS-755 FIx devel module doesn't have requirement on main module

### DIFF
--- a/alws/build_planner.py
+++ b/alws/build_planner.py
@@ -339,7 +339,7 @@ class BuildPlanner:
                     self._request_platforms[platform.name]
                 )
                 module_index.add_module(module)
-                if module_index.has_devel_module():
+                if module_index.has_devel_module() and not module.is_devel:
                     devel_module = module_index.get_module(
                         f'{task.module_name}-devel', task.module_stream)
                     devel_module.version = module.version
@@ -348,6 +348,8 @@ class BuildPlanner:
                     devel_module.set_arch_list(
                         self._request_platforms[platform.name]
                     )
+                    devel_module.add_module_dependency_to_devel_module(
+                        module=module)
                 module_pulp_href, sha256 = await self._pulp_client.create_module(
                     module_index.render(),
                     module.name,

--- a/alws/utils/modularity.py
+++ b/alws/utils/modularity.py
@@ -191,6 +191,12 @@ class ModuleWrapper:
         self._stream.clear_dependencies()
         self._stream.add_dependencies(new_deps)
 
+    def add_module_dependency_to_devel_module(self, module):
+        deps = self._stream.get_dependencies()[0]
+        deps.add_runtime_stream(module.name, module.stream)
+        self._stream.clear_dependencies()
+        self._stream.add_dependencies(deps)
+
     def get_build_deps(self) -> dict:
         build_deps = {}
         # try to extract a detailed requirements list from the


### PR DESCRIPTION
When we build module we build 2 modules actually:
- NAME
- NAME-devel

devel module must have requirement on main module.
So for example if we build subversion-devel:1.10 module it should require subversion:1.10