### PR TITLE
ALBS-787 Fix mock option in build flavor is not added to build config

### DIFF
--- a/alws/routers/build_node.py
+++ b/alws/routers/build_node.py
@@ -103,14 +103,17 @@ async def get_task(
     if task.build.platform_flavors:
         for flavour in task.build.platform_flavors:
             if flavour.data:
-                if flavour.data['mock']:
-                    if flavour.data['mock']['macros']:
-                        response['platform'].data['mock']['macros'].update(
-                            flavour.data['mock']['macros']
-                        )
-                if flavour.data['definitions']:
-                    response['platform'].data['definitions'].update(
-                        flavour.data['definitions']
+                for key in ("macros", "secure_boot_macros"):
+                    if  "mock" not in flavour.data or key not in flavour.data["mock"]:
+                        continue
+                    if key not in response["platform"].data["mock"]:
+                        response["platform"].data["mock"][key] = {}
+                    response["platform"].data["mock"][key].update(
+                        flavour.data["mock"][key]
+                    )
+                if "definitions" in flavour.data:
+                    response["platform"].data["definitions"].update(
+                        flavour.data["definitions"]
                     )
             for repo in flavour.repos:
                 if repo.arch == task.arch:

--- a/reference_data/platforms.yaml
+++ b/reference_data/platforms.yaml
@@ -61,7 +61,7 @@
       environment:
         DFLTCC: '0'
       use_bootstrap_container: false
-      macros:
+      secure_boot_macros:
         "%__pesign_cert": "%pe_signing_cert"
         "%__pesign_client_cert": "%pe_signing_cert"
         "%__pesign_client_token": "%pe_signing_token"
@@ -1485,7 +1485,7 @@
       package_manager: dnf
       releasever: '9'
       use_bootstrap_container: false
-      macros:
+      secure_boot_macros:
         "%pe_signing_cert": "Cloud Linux Software, Inc"
         "%pe_signing_token": "profil standardowy"
         "%_pesign": "/usr/local/bin/pesign"


### PR DESCRIPTION
Mock option in build flavor is not added to build config
It should be work like it works in secure boot builds