### PR TITLE
Use 1 log repository per build

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -26,6 +26,7 @@ jobs:
           echo POSTGRES_PASSWORD="password" >> ./vars.env
           echo JWT_SECRET="secret" >> ./vars.env
           echo POSTGRES_DB="test-almalinux-bs" >> ./vars.env
+          echo PACKAGE_BEHOLDER_ENABLED="False" >> ./vars.env
           echo DATABASE_URL="postgresql+asyncpg://postgres:password@db/test-almalinux-bs" >> ./vars.env
           echo SYNC_DATABASE_URL="postgresql+psycopg2://postgres:password@db/test-almalinux-bs" >> ./vars.env
           echo PULP_DATABASE_URL="postgresql+psycopg2://postgres:password@db/test-almalinux-bs" >> ./vars.env

--- a/alws/build_planner.py
+++ b/alws/build_planner.py
@@ -204,6 +204,10 @@ class BuildPlanner:
             self, task: build_schema.BuildTaskModuleRef,
             has_devel: bool = False
     ) -> typing.Dict[str, typing.List[dict]]:
+
+        if not settings.package_beholder_enabled:
+            return {}
+
         beholder_client = BeholderClient(
             settings.beholder_host, token=settings.beholder_token)
         multilib_artifacts = {}
@@ -269,6 +273,10 @@ class BuildPlanner:
             task: build_schema.BuildTaskModuleRef,
             platform_name: str, platform_version: str, task_arch: str,
     ) -> dict:
+
+        if not settings.package_beholder_enabled:
+            return {}
+
         beholder = BeholderClient(
             settings.beholder_host, token=settings.beholder_token)
         clean_name = get_clean_distr_name(platform_name)
@@ -336,7 +344,7 @@ class BuildPlanner:
             #  accordingly
             multilib_artifacts = await self.get_multilib_artifacts(
                 task, has_devel=index.has_devel_module())
-            multilib_artifacts = multilib_artifacts[platform.name]
+            multilib_artifacts = multilib_artifacts.get(platform.name, [])
             await MultilibProcessor.update_module_index(
                 index, task.module_name, task.module_stream,
                 multilib_artifacts

--- a/alws/crud/roles.py
+++ b/alws/crud/roles.py
@@ -26,13 +26,15 @@ async def fix_roles_actions(db: Session, commit: bool = False):
     new_roles = []
 
     for role in roles:
+        print(role.name)
         r_actions = None
         for act_role in RolesList:
+            print(act_role.name)
             if role.name.endswith(act_role.name):
                 r_actions = set(act_role.actions)
                 break
-        if not r_actions:
-            raise ValueError(f'No actions found for the role {role.name}')
+    if not r_actions:
+        raise ValueError(f'No actions found for the role {role.name}')
 
         required_actions_mapping = {a.name: a for a in actions
                                     if a.name in r_actions}

--- a/alws/crud/roles.py
+++ b/alws/crud/roles.py
@@ -26,10 +26,8 @@ async def fix_roles_actions(db: Session, commit: bool = False):
     new_roles = []
 
     for role in roles:
-        print(role.name)
         r_actions = None
         for act_role in RolesList:
-            print(act_role.name)
             if role.name.endswith(act_role.name):
                 r_actions = set(act_role.actions)
                 break

--- a/alws/dramatiq/__init__.py
+++ b/alws/dramatiq/__init__.py
@@ -29,7 +29,7 @@ dramatiq.set_broker(rabbitmq_broker)
 event_loop = asyncio.get_event_loop()
 
 # Tasks import started from here
-from alws.dramatiq.build import start_build, build_done, create_log_repo
+from alws.dramatiq.build import start_build, build_done
 # dramatiq.user and dramatiq.products need to go before dramatiq.releases
 from alws.dramatiq.products import perform_product_modification
 from alws.dramatiq.user import perform_user_removal

--- a/alws/dramatiq/build.py
+++ b/alws/dramatiq/build.py
@@ -25,7 +25,7 @@ from alws.dependencies import get_db
 from alws.dramatiq import event_loop
 
 
-__all__ = ['start_build', 'build_done', 'create_log_repo']
+__all__ = ['start_build', 'build_done']
 
 
 def _sync_fetch_build(db: SyncSession, build_id: int) -> models.Build:
@@ -101,12 +101,6 @@ async def _build_done(request: build_node_schema.BuildDone):
             await db.commit()
 
 
-async def _create_log_repo(task_id: int):
-    async for db in get_db():
-        task = await build_node_crud.get_build_task(db, task_id)
-        await build_node_crud.create_build_log_repo(db, task)
-
-
 async def _get_build_id(db: Session, build_task_id: int) -> int:
     async with db.begin():
         build_id = (await db.execute(select(models.BuildTask.build_id).where(
@@ -168,12 +162,3 @@ def start_build(build_id: int, build_request: Dict[str, Any]):
 def build_done(request: Dict[str, Any]):
     parsed_build = build_node_schema.BuildDone(**request)
     event_loop.run_until_complete(_build_done(parsed_build))
-
-
-@dramatiq.actor(
-    max_retries=0,
-    priority=0,
-    time_limit=DRAMATIQ_TASK_TIMEOUT,
-)
-def create_log_repo(task_id: int):
-    event_loop.run_until_complete(_create_log_repo(task_id))

--- a/alws/models.py
+++ b/alws/models.py
@@ -448,15 +448,6 @@ class BuildTask(Base):
     built_srpm_url = sqlalchemy.Column(sqlalchemy.VARCHAR, nullable=True)
     error = sqlalchemy.Column(sqlalchemy.Text, nullable=True, default=None)
 
-    def get_log_repo_name(self):
-        return '-'.join([
-            self.platform.name,
-            self.arch,
-            str(self.build_id),
-            'artifacts',
-            str(self.id)
-        ])
-
 
 class BuildTaskRef(Base):
 

--- a/alws/routers/build_node.py
+++ b/alws/routers/build_node.py
@@ -2,7 +2,6 @@ import datetime
 import itertools
 import typing
 from fastapi import APIRouter, Depends, Response, status
-from dramatiq import pipeline
 
 from alws import database, dramatiq
 from alws.auth import get_current_user
@@ -47,14 +46,7 @@ async def build_done(
     # in the future this probably should be handled somehow better
     build_task.ts = datetime.datetime.utcnow() + datetime.timedelta(hours=3)
     await db.commit()
-    if not await build_node.log_repo_exists(db, build_task):
-        pipe = pipeline([
-            dramatiq.create_log_repo.message(build_task.id),
-            dramatiq.build_done.message_with_options(args=(build_done_.dict(), ), pipe_ignore=True)
-        ])
-        pipe.run()
-    else:
-        dramatiq.build_done.send(build_done_.dict())
+    dramatiq.build_done.send(build_done_.dict())
     return {'ok': True}
 
 

--- a/tests/fixtures/dramatiq.py
+++ b/tests/fixtures/dramatiq.py
@@ -20,6 +20,7 @@ async def start_build(
     modular_build_payload: dict,
     create_module,
     create_build_rpm_repo,
+    create_log_repo,
     modify_repository,
 ):
     await _start_build(modular_build.id, BuildCreate(**modular_build_payload))

--- a/tests/fixtures/pulp.py
+++ b/tests/fixtures/pulp.py
@@ -263,3 +263,16 @@ def get_rpm_repo_by_params(monkeypatch):
         }
 
     monkeypatch.setattr(PulpClient, "get_rpm_repository_by_params", func)
+
+
+@pytest.fixture
+def create_log_repo(monkeypatch):
+    async def func(*args, **kwargs):
+        _, repo_name = args
+        repo_prefix = kwargs["distro_path_start"]
+        return (
+            f"{settings.pulp_host}/pulp/content/{repo_prefix}/{repo_name}/",
+            get_repo_href(),
+        )
+
+    monkeypatch.setattr(PulpClient, "create_log_repo", func)


### PR DESCRIPTION
Currently we produce a build log repository for each build task. To make matters worse we produce test log repositories in the same fashion. All this puts a lot of pressure on the Pulp while creating build/making it finished. To avoid these problems we migrate to the flow when we have only 1 build log repository per build and one test log repository.