### PR TITLE
Fix settings path in setup code snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,12 @@ In case you are building containers for the first time, there is how it should b
 
 set -e pipefail
 
-mkdir -p volumes/pulp/settings
+mkdir -p ../volumes/pulp/settings
 
 echo "CONTENT_ORIGIN='http://pulp'
 ANSIBLE_API_HOSTNAME='http://pulp'
 ANSIBLE_CONTENT_HOSTNAME='http://pulp/pulp/content'
-TOKEN_AUTH_DISABLED=True" >> volumes/pulp/settings/settings.py
+TOKEN_AUTH_DISABLED=True" >> ../volumes/pulp/settings/settings.py
 
 docker-compose up -d --build --force-recreate --remove-orphans
 sleep 25


### PR DESCRIPTION
The code snippet for setting up albs-web-server using docker-compose creates the settings file in an incorrect location, causing an error when resetting the admin password.
The problem is that the volumes directory should not be created in the directory where the docker-compose.yml file is located, but rather the parent directory.

This commit fixes the path in the code snippet so that settings.py is created in the correct location.

This is a very trivial PR, but it took me a bit to understand why the error was shown, so I figured it's worth submitting this. :)
