### PR TITLE
ALBS-1024: Fixed bootstrap scripts

### DIFF
--- a/alws/schemas/platform_schema.py
+++ b/alws/schemas/platform_schema.py
@@ -38,6 +38,7 @@ class PlatformCreate(BaseModel):
     priority: typing.Optional[int] = None
     test_dist_name: typing.Optional[str]
     arch_list: typing.List[str]
+    copy_priority_arches: typing.Optional[typing.List[str]] = None
     weak_arch_list: typing.Optional[typing.List[typing.Dict]] = None
     repos: typing.Optional[typing.List[RepositoryCreate]]
     data: typing.Optional[typing.Dict[str, typing.Any]]

--- a/scripts/bootstrap_permissions.py
+++ b/scripts/bootstrap_permissions.py
@@ -44,7 +44,7 @@ async def main():
         )
         await create_product(
             db, ProductCreate(name=DEFAULT_PRODUCT, team_id=alma_team.id,
-                              owner_id=system_user.id, title=DEFAULT_PRODUCT)
+                              owner_id=system_user.id, title=DEFAULT_PRODUCT, is_community=False)
         )
         await db.execute(update(models.SignKey).where(
             models.SignKey.owner_id.is_(None)).values(owner_id=system_user.id))


### PR DESCRIPTION
**Summary: every database deployment script was outdated.**

- The initial problem happened because the deployment script didn’t set the 'product.is_community' flag correctly;
- The second problem happened because pulp’s gunicorn query parameter length limit was too small (4096);
- The last problem happened because PlatformCreate model was outdated in bootstrap_repositories.py script.

See for details: https://cloudlinux.atlassian.net/browse/ALBS-1024 