### PR TITLE
Use pull_request_target to allow commenting on PRs coming from forks

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,6 +1,6 @@
 name: pytest
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - "**"
 jobs:


### PR DESCRIPTION
We have tested this, see https://github.com/javihernandez/albs-web-server/pull/4 
