### PR TITLE
ALBS-1034: Fix secure boot macro in flavours

### DIFF
--- a/reference_data/platform_flavors.yaml
+++ b/reference_data/platform_flavors.yaml
@@ -9,7 +9,7 @@
         dist_prefix: 'el8.8.0'
   data:
      mock:
-       macros:
+       secure_boot_macros:
          "%pe_signing_cert": "'f4217b7b99a69128'"
          "%pe_signing_token": "'AlmaLinux OS Foundation'"
   repositories:
@@ -102,7 +102,7 @@
         dist_prefix: 'el9.2.0'
   data:
      mock:
-       macros:
+       secure_boot_macros:
          "%pe_signing_cert": 'f4217b7b99a69128'
          "%pe_signing_token": 'AlmaLinux OS Foundation'
   repositories:


### PR DESCRIPTION
Before: 
https://cloudlinux.atlassian.net/browse/ALBS-1034 

After:
Secure boot OFF:
<img width="1171" alt="Screenshot 2023-04-05 at 4 17 16 PM" src="https://user-images.githubusercontent.com/10865942/230109387-5e355ce0-8bf3-406d-a0ab-f46f3a97662b.png">

Secure boot ON:
<img width="1173" alt="Screenshot 2023-04-05 at 4 16 49 PM" src="https://user-images.githubusercontent.com/10865942/230109474-b637ee7a-3053-4fec-a8ba-cb668cbd424f.png">
