### PR TITLE
Undo ALBS-278: Added kernel-rpm-macros package to setup_chroot_cmd

### DIFF
--- a/reference_data/platforms.yaml
+++ b/reference_data/platforms.yaml
@@ -49,7 +49,6 @@
       chroot_setup_cmd: install tar gcc-c++ redhat-rpm-config almalinux-release which xz sed
         make bzip2 gzip gcc coreutils unzip shadow-utils diffutils cpio bash gawk rpm-build
         info patch util-linux findutils grep zlib scl-utils scl-utils-build git-core
-        kernel-rpm-macros
       dnf_common_opts:
         - --setopt=deltarpm=False
         - --allowerasing
@@ -1446,7 +1445,6 @@
       chroot_setup_cmd: install tar gcc-c++ redhat-rpm-config almalinux-release which xz sed
         make bzip2 gzip gcc coreutils unzip shadow-utils diffutils cpio bash gawk rpm-build
         info patch util-linux findutils grep zlib scl-utils scl-utils-build git-core
-        kernel-rpm-macros
       dnf_common_opts:
         - --setopt=deltarpm=False
         - --allowerasing


### PR DESCRIPTION
kernel-rpm-macros package causes `kmod-kvdo` package to Provide `ksym(*) = *` entries which is not right.
The only reason to add this package to setup_chroot_cmd was modules signing but it's not actually required for that.