### PR TITLE
Add missing --capability=cap_ipc_lock to nspawn_args

### DIFF
--- a/reference_data/platforms.yaml
+++ b/reference_data/platforms.yaml
@@ -61,7 +61,7 @@
         DFLTCC: '0'
       use_bootstrap_container: false
       nspawn_args:
-        - '--rlimit=RLIMIT_NOFILE=20480'
+        - '--capability=cap_ipc_lock --rlimit=RLIMIT_NOFILE=20480'
       secure_boot_macros:
         "%__pesign_cert": "%pe_signing_cert"
         "%__pesign_client_cert": "%pe_signing_cert"
@@ -1454,7 +1454,7 @@
       releasever: '9'
       use_bootstrap_container: false
       nspawn_args:
-        - '--rlimit=RLIMIT_NOFILE=20480'
+        - '--capability=cap_ipc_lock --rlimit=RLIMIT_NOFILE=20480'
       secure_boot_macros:
         "%pe_signing_cert": "Cloud Linux Software, Inc"
         "%pe_signing_token": "profil standardowy"


### PR DESCRIPTION
The way how `nspawn_args` is implemented now in ALBS rewrites `--capability=cap_ipc_lock` argument which is used by default in mock.
This PR brings it back.