### PR TITLE
ALBS-1080: Fix logs repository creation

### DIFF
--- a/alws/build_planner.py
+++ b/alws/build_planner.py
@@ -146,6 +146,13 @@ class BuildPlanner:
 
     async def init_build_repos(self):
         tasks = []
+
+        # Add build log and test log repositories
+        for repo_type, repo_prefix in (
+                ('build_log', 'build_logs'), ('test_log', 'test_logs')):
+            tasks.append(self.create_log_repo(
+                repo_type, repo_prefix=repo_prefix))
+
         for platform in self._platforms:
             for arch in self._request_platforms[platform.name]:
                 tasks.append(self.create_build_repo(
@@ -162,12 +169,6 @@ class BuildPlanner:
 
             # Add source RPM repository
             tasks.append(self.create_build_repo(platform, 'src', 'rpm'))
-
-            # Add build log and test log repositories
-            for repo_type, repo_prefix in (
-                    ('build_log', 'build_logs'), ('test_log', 'test_logs')):
-                tasks.append(self.create_log_repo(
-                    repo_type, repo_prefix=repo_prefix))
 
         await asyncio.gather(*tasks)
 


### PR DESCRIPTION
### Was:
```
[2023-04-18 09:57:53,410] [PID 29] [MainThread] [dramatiq.WorkerProcess(8)] [INFO] Worker process is ready for action.
[2023-04-18 09:57:53,332] [PID 30] [MainThread] [dramatiq.WorkerProcess(9)] [INFO] Worker process is ready for action.
[2023-04-18 09:57:53,170] [PID 31] [MainThread] [dramatiq.WorkerProcess(10)] [INFO] Worker process is ready for action.
[2023-04-18 09:57:53,419] [PID 32] [MainThread] [dramatiq.WorkerProcess(11)] [INFO] Worker process is ready for action.
[2023-04-18 09:57:53,426] [PID 640] [MainThread] [dramatiq.ForkProcess(0)] [INFO] Fork process 'dramatiq.middleware.prometheus:_run_exposition_server' is ready for action.
[2023-04-18 18:22:56,886] [PID 23] [Thread-40] [dramatiq.worker.WorkerThread] [ERROR] Failed to process message start_build(1, {'platforms': [{'name': 'AlmaLinux-8', 'arch_list': ['x86_64', 'i686'], 'parallel_mode_enabled': True}, {'name': 'AlmaLinux-9', 'arch_list': ['i686', 'x86_64'], 'parallel_mode_enabled': True}], 'tasks': [{'url': 'https://git.almalinux.org/almalinux/pungi.git', 'git_ref': 'pungi-4.3.7-4.alma', 'ref_type': 4, 'git_commit_hash': None, 'mock_options': {}, 'is_module': False, 'enabled': True, 'added_artifacts': [], 'module_platform_version': None, 'module_version': None}], 'linked_builds': [], 'mock_options': {}, 'platform_flavors': [3], 'is_secure_boot': False, 'product_id': 1}) with unhandled exception.
Traceback (most recent call last):
  File "/code/env/lib/python3.9/site-packages/dramatiq/worker.py", line 485, in process_message
    res = actor(*message.args, **message.kwargs)
  File "/code/env/lib/python3.9/site-packages/dramatiq/actor.py", line 177, in __call__
    return self.fn(*args, **kwargs)
  File "/code/./alws/dramatiq/build.py", line 178, in start_build
    event_loop.run_until_complete(_start_build(build_id, parsed_build))
  File "/usr/lib64/python3.9/asyncio/base_events.py", line 647, in run_until_complete
    return future.result()
  File "/code/./alws/dramatiq/build.py", line 79, in _start_build
    await planner.init_build_repos()
  File "/code/./alws/build_planner.py", line 172, in init_build_repos
    await asyncio.gather(*tasks)
  File "/code/./alws/build_planner.py", line 135, in create_log_repo
    repo_url, repo_href = await self._pulp_client.create_log_repo(
  File "/code/./alws/utils/pulp_client.py", line 45, in create_log_repo
    response = await self.request("POST", ENDPOINT, json=payload)
  File "/code/./alws/utils/pulp_client.py", line 875, in request
    raise exc
  File "/code/./alws/utils/pulp_client.py", line 871, in request
    response.raise_for_status()
  File "/code/env/lib64/python3.9/site-packages/aiohttp/client_reqrep.py", line 1005, in raise_for_status
    raise ClientResponseError(
aiohttp.client_exceptions.ClientResponseError: 400, message="Bad Request: {'name': ['This field must be unique.']}", url=URL('http://albs-pulp/pulp/api/v3/repositories/file/file/')
[2023-04-18 18:22:56,891] [PID 23] [Thread-40] [dramatiq.middleware.retries.Retries] [WARNING] Retries exceeded for message 'c6199d44-dc9a-460c-af87-39a5cde92213'.
```
### Actual:

<img width="792" alt="image" src="https://user-images.githubusercontent.com/10865942/232880749-589c015f-1063-465f-945c-6551d3bba258.png">

