### PR TITLE
NOJIRA: Pin typing extensions to 4.5.0 to workaround bug in pydantic

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ aioredis==2.0.1
 alembic==1.10.3
 pytest==7.3.1
 pytest-cov==4.0.0
+typing-extensions==4.5.0
 jmespath==1.0.1
 PyYAML==6.0
 lxml==4.9.2


### PR DESCRIPTION
See https://github.com/pydantic/pydantic/issues/5821 for more info. We can remove this when we get a new version of pydantic.