### PR TITLE
Revert "Bump fastapi-users[all] from 10.4.1 to 12.1.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 fastapi[all]==0.95.1
-fastapi-users[all]==12.1.0
+fastapi-users[all]==10.4.1
 uvicorn==0.21.1
 asyncpg==0.27.0
 psycopg2-binary==2.9.6


### PR DESCRIPTION
Reverts AlmaLinux/albs-web-server#587