### PR TITLE
AlmaLinux/build-system#57: Mount the sources to a container (albs-web-server, albs-sign-node) instead store them into a container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ RUN mkdir -p /code && \
                 python3-libmodulemd1 modulemd-tools python-gobject git -y && \
     yum clean all
 RUN curl https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh -o wait_for_it.sh && chmod +x wait_for_it.sh
-COPY requirements.txt /tmp/requirements.txt
+COPY requirements.txt /code/requirements.txt
 RUN cd /code && virtualenv -p python3.9 --system-site-packages env && source env/bin/activate \
-    && pip3 install --upgrade pip && pip3 install -r /tmp/requirements.txt --no-cache-dir
+    && pip3 install --upgrade pip && pip3 install -r /code/requirements.txt --no-cache-dir
 WORKDIR /code
-CMD ["/bin/bash", "-c", "source env/bin/activate && uvicorn --workers 4 --host 0.0.0.0 alws.app:app"]
+CMD ["/bin/bash", "-c", "source env/bin/activate && pip3 install --upgrade pip && pip3 install -r requirements.txt --no-cache-dir && uvicorn --workers 4 --host 0.0.0.0 alws.app:app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,5 @@ RUN curl https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for
 COPY requirements.txt /tmp/requirements.txt
 RUN cd /code && virtualenv -p python3.9 --system-site-packages env && source env/bin/activate \
     && pip3 install --upgrade pip && pip3 install -r /tmp/requirements.txt --no-cache-dir
-COPY alws /code/alws
-COPY tests /code/tests
 WORKDIR /code
 CMD ["/bin/bash", "-c", "source env/bin/activate && uvicorn --workers 4 --host 0.0.0.0 alws.app:app"]

--- a/Dockerfile.git-cacher
+++ b/Dockerfile.git-cacher
@@ -5,10 +5,8 @@ RUN mkdir -p /code && \
     yum install python3-virtualenv python38 -y && \
     yum clean all
 RUN curl https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh -o wait_for_it.sh && chmod +x wait_for_it.sh
-COPY ./alws/scripts/git_cacher/requirements.txt /tmp/requirements.txt
+COPY ./alws/scripts/git_cacher/requirements.txt /code/requirements.txt
 RUN cd /code && virtualenv -p python3.8 env && source env/bin/activate \
-    && pip3 install --upgrade pip && pip3 install -r /tmp/requirements.txt --no-cache-dir
-COPY ./alws /code/alws
-COPY ./alws/scripts/git_cacher/git_cacher.py /code/
+    && pip3 install --upgrade pip && pip3 install -r /code/requirements.txt --no-cache-dir
 WORKDIR /code
-CMD ["/bin/bash", "-c", "source env/bin/activate && python git_cacher.py"]
+CMD ["/bin/bash", "-c", "source env/bin/activate && pip3 install --upgrade pip && pip3 install -r requirements.txt --no-cache-dir && python git_cacher.py"]

--- a/Dockerfile.gitea-listener
+++ b/Dockerfile.gitea-listener
@@ -9,4 +9,4 @@ COPY ./alws/scripts/albs-gitea-listener/requirements.txt /code/requirements.txt
 RUN cd /code && virtualenv -p python3.8 env && source env/bin/activate \
     && pip3 install --upgrade pip && pip3 install -r /code/requirements.txt --no-cache-dir
 WORKDIR /code
-CMD ["/bin/bash", "-c", "source env/bin/activate && pip3 install --upgrade pip && pip3 install -r /code/requirements.txt --no-cache-dir && python gitea_listener.py"]
+CMD ["/bin/bash", "-c", "source env/bin/activate && pip3 install --upgrade pip && pip3 install -r requirements.txt --no-cache-dir && python3 gitea_listener.py"]

--- a/Dockerfile.gitea-listener
+++ b/Dockerfile.gitea-listener
@@ -5,11 +5,8 @@ RUN mkdir -p /code && \
     yum install python3-virtualenv python38 -y && \
     yum clean all
 RUN curl https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh -o wait_for_it.sh && chmod +x wait_for_it.sh
-COPY ./alws/scripts/albs-gitea-listener/requirements.txt /tmp/requirements.txt
+COPY ./alws/scripts/albs-gitea-listener/requirements.txt /code/requirements.txt
 RUN cd /code && virtualenv -p python3.8 env && source env/bin/activate \
-    && pip3 install --upgrade pip && pip3 install -r /tmp/requirements.txt --no-cache-dir
-COPY ./alws/scripts/albs-gitea-listener/* /code/
-COPY ./alws/scripts/git_cacher/git_cacher.py /code/
-COPY ./alws /code/alws
+    && pip3 install --upgrade pip && pip3 install -r /code/requirements.txt --no-cache-dir
 WORKDIR /code
-CMD ["/bin/bash", "-c", "source env/bin/activate && python gitea_listener.py"]
+CMD ["/bin/bash", "-c", "source env/bin/activate && pip3 install --upgrade pip && pip3 install -r /code/requirements.txt --no-cache-dir && python gitea_listener.py"]

--- a/Dockerfile.task-queue
+++ b/Dockerfile.task-queue
@@ -7,10 +7,8 @@ RUN mkdir -p /code && \
                 python3-libmodulemd1 modulemd-tools python-gobject git -y && \
     yum clean all
 RUN curl https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh -o wait_for_it.sh && chmod +x wait_for_it.sh
-COPY requirements.txt /tmp/requirements.txt
+COPY requirements.txt /code/requirements.txt
 RUN cd /code && virtualenv -p python3.9 --system-site-packages env && source env/bin/activate \
-    && pip3 install --upgrade pip && pip3 install -r /tmp/requirements.txt --no-cache-dir
-COPY alws /code/alws
-COPY tests /code/tests
+    && pip3 install --upgrade pip && pip3 install -r /code/requirements.txt --no-cache-dir
 WORKDIR /code
-CMD ["/bin/bash", "-c", "source env/bin/activate && "dramatiq alws.dramatiq.build"]
+CMD ["/bin/bash", "-c", "source env/bin/activate && pip3 install --upgrade pip && pip3 install -r /code/requirements.txt --no-cache-dir && "dramatiq alws.dramatiq.build"]

--- a/Dockerfile.task-queue
+++ b/Dockerfile.task-queue
@@ -11,4 +11,4 @@ COPY requirements.txt /code/requirements.txt
 RUN cd /code && virtualenv -p python3.9 --system-site-packages env && source env/bin/activate \
     && pip3 install --upgrade pip && pip3 install -r /code/requirements.txt --no-cache-dir
 WORKDIR /code
-CMD ["/bin/bash", "-c", "source env/bin/activate && pip3 install --upgrade pip && pip3 install -r /code/requirements.txt --no-cache-dir && "dramatiq alws.dramatiq.build"]
+CMD ["/bin/bash", "-c", "source env/bin/activate && pip3 install --upgrade pip && pip3 install -r requirements.txt --no-cache-dir && "dramatiq alws.dramatiq.build"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -211,13 +211,9 @@ services:
       - rabbitmq
 
   frontend:
-    image: albs-frontend:latest
+    image: quay.io/almalinuxorg/albs-frontend:latest
     env_file:
       - vars.env
-    build:
-      dockerfile: Dockerfile
-      # TODO: Hack for developement, put https://github.com/AlmaLinux/albs-frontend here instead
-      context: ../albs-frontend
     command: bash -c "npm install && npm run dev"
     volumes:
       - "../albs-frontend:/code"
@@ -244,18 +240,18 @@ services:
       - web_server
 
   sign_node:
-    image: sign-node:latest
+    image: quay.io/almalinuxorg/albs-sign-node:latest
     env_file:
       - vars.env
-    build:
-      context: ../albs-sign-node
-      dockerfile: Dockerfile
     volumes:
       # TODO: Hack for developement, put placeholder here instead
       - "../albs-sign-node/node-config:/home/alt/.config"
       - "~/.gnupg:/home/alt/.gnupg"
+      - "../albs-sign-node/almalinux_sign_node.py:/sign-node/almalinux_sign_node.py"
+      - "../albs-sign-node:/sign-node/sign_node"
+      - "../albs-sign-node/requirements.txt:/sign-node/requirements.txt"
     restart: on-failure
-    command: "bash -c '/wait_for_it.sh web_server:8000 && source env/bin/activate && ./almalinux_sign_node.py -v'"
+    command: "bash -c '/wait_for_it.sh web_server:8000 && source env/bin/activate && pip3 install --upgrade pip && pip3 install -r requirements.txt --no-cache-dir && python3 almalinux_sign_node.py -v'"
 
   gitea_listener:
     image: quay.io/almalinuxorg/gitea-listener:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,7 +81,7 @@ services:
                  /wait_for_it.sh db:5432 &&
                  PYTHONPATH="." alembic --config alws/alembic.ini upgrade head &&
                  pip3 install --upgrade pip &&
-                 pip3 install -r /code/requirements.txt
+                 pip3 install -r requirements.txt
                  uvicorn --host 0.0.0.0 alws.app:app'
     restart: on-failure
     depends_on:
@@ -89,7 +89,7 @@ services:
       - pulp
 
   task_queue:
-    image: albs-task-queue:latest
+    image: quay.io/almalinuxorg/task-queue:latest
     env_file:
       - vars.env
     build:
@@ -104,7 +104,7 @@ services:
     command: bash -c 'source env/bin/activate &&
                       /wait_for_it.sh rabbitmq:5672 &&
                       pip3 install --upgrade pip && 
-                      pip3 install -r /code/requirements.txt --no-cache-dir &&
+                      pip3 install -r requirements.txt --no-cache-dir &&
                       dramatiq alws.dramatiq --threads 1 -Q default'
     restart: on-failure
     depends_on:
@@ -113,7 +113,7 @@ services:
       - rabbitmq
 
   task_queue_builds:
-    image: albs-task-queue:latest
+    image: quay.io/almalinuxorg/task-queue:latest
     env_file:
       - vars.env
     build:
@@ -121,8 +121,11 @@ services:
       context: .
     volumes:
       - "./alws:/code/alws"
+      - "./requirements.txt /code/requirements.txt"
     command: bash -c 'source env/bin/activate &&
                       /wait_for_it.sh rabbitmq:5672 &&
+                      pip3 install --upgrade pip && 
+                      pip3 install -r requirements.txt --no-cache-dir &&
                       dramatiq alws.dramatiq --threads 1 -Q builds'
     restart: on-failure
     depends_on:
@@ -131,7 +134,7 @@ services:
       - rabbitmq
 
   task_queue_errata:
-    image: albs-task-queue:latest
+    image: quay.io/almalinuxorg/task-queue:latest
     env_file:
       - vars.env
     build:
@@ -139,8 +142,11 @@ services:
       context: .
     volumes:
       - "./alws:/code/alws"
+      - "./requirements.txt /code/requirements.txt"
     command: bash -c 'source env/bin/activate &&
                       /wait_for_it.sh rabbitmq:5672 &&
+                      pip3 install --upgrade pip && 
+                      pip3 install -r requirements.txt --no-cache-dir &&
                       dramatiq alws.dramatiq --processes 1 --threads 1 -Q errata'
     restart: on-failure
     depends_on:
@@ -149,7 +155,7 @@ services:
       - rabbitmq
 
   task_queue_releases:
-    image: albs-task-queue:latest
+    image: quay.io/almalinuxorg/task-queue:latest
     env_file:
       - vars.env
     build:
@@ -157,8 +163,11 @@ services:
       context: .
     volumes:
       - "./alws:/code/alws"
+      - "./requirements.txt /code/requirements.txt"
     command: bash -c 'source env/bin/activate &&
                       /wait_for_it.sh rabbitmq:5672 &&
+                      pip3 install --upgrade pip && 
+                      pip3 install -r requirements.txt --no-cache-dir &&
                       dramatiq alws.dramatiq --processes 1 --threads 1 -Q releases'
     restart: on-failure
     depends_on:
@@ -167,7 +176,7 @@ services:
       - rabbitmq
 
   task_queue_sign:
-    image: albs-task-queue:latest
+    image: quay.io/almalinuxorg/task-queue:latest
     env_file:
       - vars.env
     build:
@@ -175,12 +184,15 @@ services:
       context: .
     volumes:
       - "./alws:/code/alws"
+      - "./requirements.txt /code/requirements.txt"
     command: bash -c 'source env/bin/activate &&
+                      pip3 install --upgrade pip && 
+                      pip3 install -r requirements.txt --no-cache-dir &&
                       dramatiq alws.dramatiq --processes 1 --threads 1 -Q sign'
     restart: on-failure
 
   task_queue_product_modify:
-    image: albs-task-queue:latest
+    image: quay.io/almalinuxorg/task-queue:latest
     env_file:
       - vars.env
     build:
@@ -188,12 +200,15 @@ services:
       context: .
     volumes:
       - "./alws:/code/alws"
+      - "./requirements.txt /code/requirements.txt"
     command: bash -c 'source env/bin/activate &&
+                      pip3 install --upgrade pip && 
+                      pip3 install -r requirements.txt --no-cache-dir &&
                       dramatiq alws.dramatiq --processes 3 --threads 1 -Q product_modify'
     restart: on-failure
 
   task_queue_tests:
-    image: albs-task-queue:latest
+    image: quay.io/almalinuxorg/task-queue:latest
     env_file:
       - vars.env
     build:
@@ -201,8 +216,11 @@ services:
       context: .
     volumes:
       - "./alws:/code/alws"
+      - "./requirements.txt /code/requirements.txt"
     command: bash -c 'source env/bin/activate &&
                       /wait_for_it.sh rabbitmq:5672 &&
+                      pip3 install --upgrade pip && 
+                      pip3 install -r requirements.txt --no-cache-dir &&
                       dramatiq alws.dramatiq --processes 1 --threads 1 -Q tests'
     restart: on-failure
     depends_on:
@@ -223,7 +241,7 @@ services:
       - web_server
 
   build_node:
-    image: albs-node:latest
+    image: quay.io/almalinuxorg/albs-node:latest
     privileged: true
     env_file:
       - vars.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,14 +63,11 @@ services:
       - rabbitmq
 
   web_server:
-    image: al-web-server:latest
+    image: quay.io/almalinuxorg/albs:latest
     env_file:
       - vars.env
     ports:
       - "8088:8000"
-    build:
-      dockerfile: Dockerfile
-      context: .
     volumes:
       - "./alws:/code/alws"
       - "./tests:/code/tests"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,6 +70,7 @@ services:
       - "8088:8000"
     volumes:
       - "./alws:/code/alws"
+      - "./requirements.txt:/code/requirements.txt"
       - "./tests:/code/tests"
       - "./almalinux:/code/almalinux"
       - "./scripts:/code/scripts"
@@ -79,6 +80,8 @@ services:
         bash -c 'source env/bin/activate &&
                  /wait_for_it.sh db:5432 &&
                  PYTHONPATH="." alembic --config alws/alembic.ini upgrade head &&
+                 pip3 install --upgrade pip &&
+                 pip3 install -r /code/requirements.txt
                  uvicorn --host 0.0.0.0 alws.app:app'
     restart: on-failure
     depends_on:
@@ -94,10 +97,14 @@ services:
       context: .
     volumes:
       - "./alws:/code/alws"
+      - "./tests:/code/tests"
       - "./scripts:/code/scripts"
       - "./reference_data:/code/reference_data"
+      - "./requirements.txt /code/requirements.txt"
     command: bash -c 'source env/bin/activate &&
                       /wait_for_it.sh rabbitmq:5672 &&
+                      pip3 install --upgrade pip && 
+                      pip3 install -r /code/requirements.txt --no-cache-dir &&
                       dramatiq alws.dramatiq --threads 1 -Q default'
     restart: on-failure
     depends_on:
@@ -251,26 +258,29 @@ services:
     command: "bash -c '/wait_for_it.sh web_server:8000 && source env/bin/activate && ./almalinux_sign_node.py -v'"
 
   gitea_listener:
-    image: albs-gitea-listener:latest
+    image: quay.io/almalinuxorg/gitea-listener:latest
     env_file:
       - vars.env
-    build:
-      context: .
-      dockerfile: Dockerfile.gitea-listener
     restart: on-failure
     depends_on:
       - mosquitto
+    volumes:
+      - "./alws/scripts/albs-gitea-listener:/code"
+      - "./alws/scripts/git_cacher/git_cacher.py:/code/git_cacher.py"
+      - "./alws:/code/alws"
+      - "./alws/scripts/albs-gitea-listener/requirements.txt:/code/requirements.txt"
 
   git_cacher:
-    image: albs-git-cacher:latest
+    image: quay.io/almalinuxorg/git-cacher:latest
     env_file:
       - vars.env
-    build:
-      context: .
-      dockerfile: Dockerfile.git-cacher
     restart: on-failure
     depends_on:
       - redis
+    volumes:
+      - "./alws:/code/alws"
+      - "./alws/scripts/git_cacher/git_cacher.py:/code/git_cacher.py"
+      - "./requirements.txt:/code/requirements.txt"
 
   pulp:
     # image: pulp/pulp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -227,15 +227,14 @@ services:
     privileged: true
     env_file:
       - vars.env
-    build:
-      # TODO: Hack for developement, put https://github.com/AlmaLinux/albs-node here instead
-      context: ../albs-node
-      dockerfile: Dockerfile
     volumes:
       # TODO: Hack for developement, put placeholder here instead
       - "../albs-node/node-config:/home/alt/.config"
+      - "../albs-node/requirements.txt:/build-node/requirements.txt"
+      - "../albs-node/build_node:/build-node/build_node"
+      - "../albs-node/almalinux_build_node.py:/build-node/almalinux_build_node.py"
     restart: on-failure
-    command: "bash -c '/wait_for_it.sh web_server:8000 && source env/bin/activate && ./almalinux_build_node.py -v -t 2'"
+    command: "bash -c '/wait_for_it.sh web_server:8000 && source env/bin/activate && pip3 install --upgrade pip && pip3 install -r requirements.txt --no-cache-dir && python3 almalinux_build_node.py -v -t 2'"
     depends_on:
       - web_server
 


### PR DESCRIPTION
- Copying the code into the images is removed
- Pull the already built image from quay.io