### PR TITLE
Fix unpaired double quotation in errata html template

### DIFF
--- a/alws/utils/templates/errata_alma_page.j2
+++ b/alws/utils/templates/errata_alma_page.j2
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta content="text/html; charset="UTF-8">
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <title>{{ errata['updateinfo_id'] }}</title>
     <link rel="stylesheet" href="../assets/foundation.min.css">
     <link rel="stylesheet" href="../assets/images-style.css">


### PR DESCRIPTION
Found this I'm working on: https://github.com/AlmaLinux/build-system/issues/39

See also: https://www.w3.org/International/questions/qa-html-encoding-declarations.en