### PR TITLE
Implement packages sorting in errata page

### DIFF
--- a/alws/utils/errata.py
+++ b/alws/utils/errata.py
@@ -361,6 +361,10 @@ def merge_errata_records_modern(a, b):
 
 
 def dump_errata_to_html(errata):
+    # sort package list by arch
+    packages = errata["pkglist"]["packages"]
+    errata["pkglist"]["packages"] = sorted(packages, key=lambda x: x["arch"])
+
     template_dir = pathlib.Path(__file__).absolute().parent / "templates"
     template = (template_dir / "errata_alma_page.j2").read_text()
     return jinja2.Template(template).render(errata=errata)

--- a/alws/utils/templates/errata_alma_page.j2
+++ b/alws/utils/templates/errata_alma_page.j2
@@ -113,7 +113,7 @@
                                 <tr>
                                     <td>{{ pkg['arch'] }}</td>
                                     <td>{{ pkg['filename'] }}</td>
-                                    <td>{{ pkg['check'] }}</td>
+				    <td><span class="checksum">{{ pkg['sum'] }}</span></td>
                                 </tr>
                                 {% endfor %}
                             </tbody>

--- a/alws/utils/templates/errata_alma_page.j2
+++ b/alws/utils/templates/errata_alma_page.j2
@@ -5,12 +5,15 @@
     <title>{{ errata['updateinfo_id'] }}</title>
     <link rel="stylesheet" href="../assets/foundation.min.css">
     <link rel="stylesheet" href="../assets/images-style.css">
+    <link rel="stylesheet" href="../assets/theme.default.min.css">
     <link rel="shortcut icon" type="image/png" href="../assets/hero-img.png">
     <script src="../assets/jquery.js" type="text/javascript"></script>
+    <script src="../assets/jquery.tablesorter.min.js" type="text/javascript"></script>
     <script src="../assets/foundation.min.js" type="text/javascript"></script>
     <script>
       $(function () {
         $(document).foundation();
+        $('.sort-table').tablesorter({sortList: [[0,0]]});
       });
     </script>
 </head>
@@ -30,9 +33,7 @@
 </div>
 
 
-<div class="tabs-content" data-tabs-content="images-tabs">
-
-    <div class="tabs-panel row is-active">
+    <div class="row">
         <div class="row card">
             <div class="medium-12 columns card-header">
                 <h5>[{{ errata['updateinfo_id'] }}] {{ errata['title'] }}</h5>
@@ -88,27 +89,33 @@
                 {% endif %}
 
                 <div class="row">
-                    <div class="medium-3 columns text-left">
-                        <strong>Updated packages:</strong>
-                    </div>
-                    <div class="medium-9 columns">
-                        <ul style="list-style: none; margin-left: 0;"
-                            class="package_list">
-                            {% for pkg in errata['pkglist']['packages'] %}
-                            <li name="{{ pkg['name']}}"
-                                version="{{ pkg['version']}}"
-                                epoch="{{ pkg['epoch']}}"
-                                release="{{ pkg['release']}}"
-                                arch="{{ pkg['arch']}}">
-                                {{ pkg['filename'] }}<br/>
-                                <span class="checksum">
-                                    {{ pkg['checksum'] }}
-                                </span>
-                            </li>
-                            {% endfor %}
-                        </ul>
+                    <div class="medium-12 columns text-left">
+                        <strong>Updated packages listed below:</strong>
                     </div>
                 </div>
+
+		<div class="row">
+                    <div class="medium-12 columns text-left">
+                        <table class="sort-table tablesorter">
+				<thead>
+					<tr>
+					<td>Architecture</td>
+					<td>Package</td>
+					<td>Checksum</td>
+					</tr>
+				</thead>
+				<tbody>
+				{% for pkg in errata['pkglist']['packages'] %}
+					<tr>
+						<td>{{ pkg['arch'] }}</td>
+						<td>{{ pkg['filename'] }}</td>
+						<td>{{ pkg['check'] }}</td>
+					</tr>
+				{% endfor %}
+				</tbody>
+			</table>
+		    </div>
+		</div>
 
                 <div class="row">
                     <div class="medium-3 columns text-left">
@@ -121,6 +128,5 @@
             </div>
         </div>
     </div>
-</div>
 </body>
 </html>

--- a/alws/utils/templates/errata_alma_page.j2
+++ b/alws/utils/templates/errata_alma_page.j2
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <title>{{ errata['updateinfo_id'] }}</title>
@@ -11,26 +12,30 @@
     <script src="../assets/jquery.tablesorter.min.js" type="text/javascript"></script>
     <script src="../assets/foundation.min.js" type="text/javascript"></script>
     <script>
-      $(function () {
-        $(document).foundation();
-        $('.sort-table').tablesorter({sortList: [[0,0]]});
-      });
+        $(function() {
+            $(document).foundation();
+            $('.sort-table').tablesorter({
+                sortList: [
+                    [0, 0]
+                ]
+            });
+        });
     </script>
 </head>
 
 <body>
-<div class="expanded row header" style="border-bottom: 1px solid lightgrey;">
-    <div class="row expanded">
-        <div class="small-12 columns text-center" style="display: inline-block;">
-            <ul class="no-bullet header-container">
-                <li>
-                    <img class="header-logo" src="../assets/almalinux-logo.png" alt="AlmaLinux">
-		</li>
-            </ul>
-        </div>
+    <div class="expanded row header" style="border-bottom: 1px solid lightgrey;">
+        <div class="row expanded">
+            <div class="small-12 columns text-center" style="display: inline-block;">
+                <ul class="no-bullet header-container">
+                    <li>
+                        <img class="header-logo" src="../assets/almalinux-logo.png" alt="AlmaLinux">
+                    </li>
+                </ul>
+            </div>
 
+        </div>
     </div>
-</div>
 
 
     <div class="row">
@@ -67,8 +72,7 @@
                     <div class="medium-3 columns text-left">
                         <strong>Description:</strong>
                     </div>
-                    <div style="white-space: pre-wrap; vertical-align: top;"
-                         class="medium-9 columns description">{{ errata['description'] }}</div>
+                    <div style="white-space: pre-wrap; vertical-align: top;" class="medium-9 columns description">{{ errata['description'] }}</div>
                 </div>
                 {% if errata['references'] %}
                 <div class="row">
@@ -94,28 +98,28 @@
                     </div>
                 </div>
 
-		<div class="row">
+                <div class="row">
                     <div class="medium-12 columns text-left">
                         <table class="sort-table tablesorter">
-				<thead>
-					<tr>
-					<td>Architecture</td>
-					<td>Package</td>
-					<td>Checksum</td>
-					</tr>
-				</thead>
-				<tbody>
-				{% for pkg in errata['pkglist']['packages'] %}
-					<tr>
-						<td>{{ pkg['arch'] }}</td>
-						<td>{{ pkg['filename'] }}</td>
-						<td>{{ pkg['check'] }}</td>
-					</tr>
-				{% endfor %}
-				</tbody>
-			</table>
-		    </div>
-		</div>
+                            <thead>
+                                <tr>
+                                    <td>Architecture</td>
+                                    <td>Package</td>
+                                    <td>Checksum</td>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for pkg in errata['pkglist']['packages'] %}
+                                <tr>
+                                    <td>{{ pkg['arch'] }}</td>
+                                    <td>{{ pkg['filename'] }}</td>
+                                    <td>{{ pkg['check'] }}</td>
+                                </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
 
                 <div class="row">
                     <div class="medium-3 columns text-left">
@@ -124,9 +128,10 @@
                     <div class="medium-9 columns">
                         This page is generated automatically from <a href="https://www.redhat.com/security/data/oval/v2/">Red Hat security data</a> and has not been checked for errors. For clarification or corrections please contact the <a href="mailto:packager@almalinux.org">AlmaLinux Packaging Team</a>.
                     </div>
-            </div>
+                </div>
             </div>
         </div>
     </div>
 </body>
+
 </html>

--- a/alws/utils/templates/errata_alma_page.j2
+++ b/alws/utils/templates/errata_alma_page.j2
@@ -24,8 +24,8 @@
         <div class="small-12 columns text-center" style="display: inline-block;">
             <ul class="no-bullet header-container">
                 <li>
-                    <img class="header-logo" src="../assets/almalinux-logo.png" alt="AlmaLinux"></li>
-                <li>
+                    <img class="header-logo" src="../assets/almalinux-logo.png" alt="AlmaLinux">
+		</li>
             </ul>
         </div>
 


### PR DESCRIPTION
* Add ability to change sort order
* Display package checksums in errata page that was unintentionally not displayed
* Show updated packages as compact table

Merge https://github.com/AlmaLinux/errata_index/pull/4 together.