### PR TITLE
- Mount sources instead copy them into a Docker image

### DIFF
--- a/alws/crud/test.py
+++ b/alws/crud/test.py
@@ -142,7 +142,7 @@ async def restart_build_task_tests(db: AsyncSession, build_task_id: int):
         if not test_log_repository:
             raise ValueError('Cannot create test tasks: '
                              'the log repository is not found')
-        await create_test_tasks(db, build_task_id, test_log_repository.id)
+    await create_test_tasks(db, build_task_id, test_log_repository.id)
 
 
 async def __convert_to_file(pulp_client: PulpClient, artifact: dict):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -329,9 +329,9 @@ services:
               python tests_cacher.py'"
 
   pulp:
-    image: pulp/pulp
+    # image: pulp/pulp
     # after downgrading pulp you probably should to remove pulp volumes
-#    image: pulp/pulp:upgrade
+    image: pulp/pulp:upgrade
     ports:
       - 8081:80
       - 5431:5432

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,10 +25,7 @@ services:
     restart: always
 
   alts-celery:
-    image: alts-celery:latest
-    build:
-      dockerfile: Dockerfile.celery
-      context: ../alts
+    image: quay.io/almalinuxorg/alts-celery:latest
     environment:
       CELERY_CONFIG_PATH: "/celery_config.yaml"
       EXTERNAL_NETWORK: "albs-web-server_default"
@@ -50,10 +47,7 @@ services:
       - rabbitmq
 
   alts-scheduler:
-    image: alts-scheduler:latest
-    build:
-      dockerfile: Dockerfile.scheduler
-      context: ../alts
+    image: quay.io/almalinuxorg/alts-scheduler:latest
     ports:
       - "8082:8000"
     environment:
@@ -279,7 +273,7 @@ services:
       - "../albs-sign-node/node-config:/home/alt/.config"
       - "~/.gnupg:/home/alt/.gnupg"
       - "../albs-sign-node/almalinux_sign_node.py:/sign-node/almalinux_sign_node.py"
-      - "../albs-sign-node:/sign-node/sign_node"
+      - "../albs-sign-node/sign_node:/sign-node/sign_node"
       - "../albs-sign-node/requirements.txt:/sign-node/requirements.txt"
     restart: on-failure
     command: "bash -c '/wait_for_it.sh web_server:8000 &&
@@ -335,9 +329,9 @@ services:
               python tests_cacher.py'"
 
   pulp:
-    # image: pulp/pulp
+    image: pulp/pulp
     # after downgrading pulp you probably should to remove pulp volumes
-    image: pulp/pulp:upgrade
+#    image: pulp/pulp:upgrade
     ports:
       - 8081:80
       - 5431:5432


### PR DESCRIPTION
- Function `restart_build_task_tests` is fixed: call `create_test_tasks` contains `db.begin` so we need move out call from another `db.begin`