### PR TITLE
Add RSS feed generation to packages_exporter

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,7 @@ jinja2==3.1.2
 pgpy==0.6.0
 markdown==3.4.3
 httpx-oauth==0.11.2
+feedgen==0.9.0
 sentry-sdk[fastapi]==1.28.1  # requires FastAPI>=0.79.0
 git+https://github.com/AlmaLinux/immudb-wrapper.git@0.1.1#egg=immudb_wrapper
 git+https://github.com/AlmaLinux/errata2osv.git@0.0.3#egg=errata2osv

--- a/scripts/packages_exporter.py
+++ b/scripts/packages_exporter.py
@@ -384,6 +384,7 @@ class Exporter:
 
             entry = feed.add_entry()
             entry.title(title)
+            entry.link(href=link)
             entry.content(content, type='CDATA')
             entry.pubDate(pubDate)
 

--- a/scripts/packages_exporter.py
+++ b/scripts/packages_exporter.py
@@ -25,6 +25,11 @@ from sqlalchemy.future import select
 from sqlalchemy.orm import selectinload
 from syncer import sync
 
+# Required for generating RSS
+from feedgen.feed import FeedGenerator
+from datetime import datetime
+from datetime import timezone
+
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 
@@ -354,6 +359,35 @@ class Exporter:
         return await self.make_request(
             "GET", endpoint, params={"platform_name": platform_name}
         )
+
+    async def generate_rss(self, platform, modern_cache):
+        # Expect "AlmaLinux-9" here:
+        dist_name = platform.replace('-', ' ')
+        dist_version = platform.split('-')[-1]
+
+        errata_data = modern_cache['data']
+
+        feed = FeedGenerator()
+        feed.title(f'Errata Feed for {dist_name}')
+        feed.link(href='https://errata.almalinux.org', rel='alternate')
+        feed.description(f'Errata Feed for AlmaLinux')
+        feed.author(name='AlmaLinux Team', email='packager@almalinux.org')
+
+        for erratum in errata_data:
+            html_erratum_id = erratum['id'].replace(':', '-')
+            title = f"[{erratum['id']}] {erratum['title']}"
+            link = f"https://errata.almalinux.org/{dist_version}/{html_erratum_id}.html"
+            pubDate = datetime.fromtimestamp(
+                erratum['updated_date'], timezone.utc
+            )
+            content = f"<pre>{erratum['description']}</pre>"
+
+            entry = feed.add_entry()
+            entry.title(title)
+            entry.content(content, type='CDATA')
+            entry.pubDate(pubDate)
+
+        return feed.rss_str(pretty=True).decode('utf-8')
 
     async def download_repodata(self, repodata_path, repodata_url):
         file_links = await get_repodata_file_links(repodata_url)
@@ -948,6 +982,19 @@ def main():
                 with open(os.path.join(platform_path, "oval.xml"), "w") as fd:
                     fd.write(oval)
                 exporter.logger.debug("OVAL is generated")
+
+                exporter.logger.debug(f"Generating RSS feed for {platform}")
+                rss = sync(
+                    exporter.generate_rss(
+                        platform,
+                        platform_errata_cache[platform]["modern_cache"],
+                    )
+                )
+                with open(
+                    os.path.join(platform_path, "errata.rss"), "w"
+                ) as fd:
+                    fd.write(rss)
+                exporter.logger.debug(f"RSS generation for {platform} is done")
         except Exception:
             exporter.logger.exception("Error happened:\n")
         finally:

--- a/scripts/packages_exporter.py
+++ b/scripts/packages_exporter.py
@@ -11,6 +11,7 @@ import tempfile
 import typing
 import urllib.parse
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
 from pathlib import Path
 from time import time
 
@@ -20,15 +21,13 @@ import pgpy
 import rpm
 import sentry_sdk
 import sqlalchemy
+
+# Required for generating RSS
+from feedgen.feed import FeedGenerator
 from plumbum import local
 from sqlalchemy.future import select
 from sqlalchemy.orm import selectinload
 from syncer import sync
-
-# Required for generating RSS
-from feedgen.feed import FeedGenerator
-from datetime import datetime
-from datetime import timezone
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 


### PR DESCRIPTION
Outputs `errata.rss` under the following directory:

```
./exports/errata
├── AlmaLinux-9
│   ├── errata.full.json
│   ├── errata.json
│   ├── errata.rss
│   └── html
│       ├── ALSA-2022-4940.html
│       ├── ALSA-2022-5099.html
│       ├── ALSA-2022-5242.html
│       ├── ALSA-2022-5244.html
│       ├── ALSA-2022-5249.html
```

So final URL will be 
* https://errata.almalinux.org/9/errata.rss
* https://errata.almalinux.org/8/errata.rss 

This is a sample of generated RSS:
* [errata_20231004_rss.txt](https://github.com/AlmaLinux/albs-web-server/files/12800138/errata_20231004_rss.txt)
* https://w.vmeta.jp/temp/errata.rss
