### PR TITLE
AlmaLinux/build-system#113: Fix multilib in builds

### DIFF
--- a/.github/workflows/syntax.yml
+++ b/.github/workflows/syntax.yml
@@ -47,4 +47,4 @@ jobs:
       - name: Run black
         run: env/bin/black ${{ steps.changed-files.outputs.all_changed_files }} --exclude alembic --check -l 79 --skip-string-normalization --diff --color
       - name: Run isort
-        run: env/bin/isort ${{ steps.changed-files.outputs.all_changed_files }} --diff --color --profile black --check-only --py 39
+        run: env/bin/isort ${{ steps.changed-files.outputs.all_changed_files }} --diff --color --check-only --py 39 --split-on-trailing-comma

--- a/alws/crud/build_node.py
+++ b/alws/crud/build_node.py
@@ -529,7 +529,6 @@ async def __process_build_task_artifacts(
     status: BuildTaskStatus,
     git_commit_hash: typing.Optional[str],
 ) -> typing.Tuple[models.BuildTask, typing.Dict[str, typing.Dict[str, str]]]:
-
     def _get_srpm_name(
         artifacts: list[BuildDoneArtifact],
         task: models.BuildTask,

--- a/alws/utils/multilib.py
+++ b/alws/utils/multilib.py
@@ -134,7 +134,7 @@ class MultilibProcessor:
         endpoint = f"api/v1/distros/{ref_name}/{ref_ver}/project/{src_rpm}"
         response = await self.call_beholder(self._beholder_client, endpoint)
         query = (
-            "packages[?arch=='i686']"
+            "packages.*[?arch=='i686'][]"
             ".{name: name, version: version, repos: repositories}"
         )
         return await self.parse_response(query, response)


### PR DESCRIPTION
- The "multilib" call to repo-beholder is fixed
- The artifacts from other arch than `i686` don't contain sRPM. So, we should extract name of sRPM from its URL