### PR TITLE
docker-compose: correct volume path for sign_node

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -265,7 +265,7 @@ services:
       - "../albs-sign-node/node-config:/home/alt/.config"
       - "~/.gnupg:/home/alt/.gnupg"
       - "../albs-sign-node/almalinux_sign_node.py:/sign-node/almalinux_sign_node.py"
-      - "../albs-sign-node:/sign-node/sign_node"
+      - "../albs-sign-node/sign_node:/sign-node/sign_node"
       - "../albs-sign-node/requirements.txt:/sign-node/requirements.txt"
     restart: on-failure
     command: "bash -c '/wait_for_it.sh web_server:8000 && source env/bin/activate && pip3 install --upgrade pip && pip3 install -r requirements.txt --no-cache-dir && python3 almalinux_sign_node.py -v'"


### PR DESCRIPTION
Current configuration mounts sources one level deeper than expected:
```
  /sign-node/sign_node/sign_node/__init__.py
```

Correct mount path should be:
```
  /sign-node/sign_node/__init__.py
```