### PR TITLE
AlmaLinux/build-system#87: ALBS can't build multiplatform builds beca…

### DIFF
--- a/alws/crud/products.py
+++ b/alws/crud/products.py
@@ -19,11 +19,11 @@ from alws.perms import actions
 from alws.perms.authorization import can_perform
 from alws.schemas.product_schema import ProductCreate
 from alws.schemas.team_schema import TeamCreate
-from alws.utils.pulp_client import PulpClient
 from alws.utils.copr import (
     create_product_repo,
     create_product_sign_key_repo,
 )
+from alws.utils.pulp_client import PulpClient
 
 __all__ = [
     'create_product',

--- a/alws/crud/products.py
+++ b/alws/crud/products.py
@@ -61,7 +61,9 @@ async def create_product(
     if teams:
         team = teams[0]
     else:
-        team_payload = TeamCreate(team_name=team_name, user_id=payload.owner_id)
+        team_payload = TeamCreate(
+            team_name=team_name, user_id=payload.owner_id
+        )
         team = await create_team(db, team_payload, flush=True)
     team_roles = await create_team_roles(db, team_name)
 
@@ -126,7 +128,8 @@ async def create_product(
     # Create sign key repository if a product is community
     if payload.is_community:
         repo_name, repo_url, repo_href = await create_product_sign_key_repo(
-            pulp_client, owner.username, product.name)
+            pulp_client, owner.username, product.name
+        )
         repo = models.Repository(
             name=repo_name,
             url=repo_url,
@@ -272,8 +275,8 @@ async def remove_product(
         # some repos from db can be absent in pulp
         # in case if you reset pulp db, but didn't reset non-pulp db
         if all(
-                product_repo.name != product_distro['name'] for product_distro
-                in all_product_distros
+            product_repo.name != product_distro['name']
+            for product_distro in all_product_distros
         ):
             continue
         delete_tasks.append(pulp_client.delete_by_href(product_repo.pulp_href))

--- a/alws/crud/products.py
+++ b/alws/crud/products.py
@@ -271,12 +271,11 @@ async def remove_product(
     for product_repo in db_product.repositories:
         # some repos from db can be absent in pulp
         # in case if you reset pulp db, but didn't reset non-pulp db
-        #FIXME: uncomment after tests
-        # if all(
-        #         product_repo.name != product_distro['name'] for product_distro
-        #         in all_product_distros
-        # ):
-        #     continue
+        if all(
+                product_repo.name != product_distro['name'] for product_distro
+                in all_product_distros
+        ):
+            continue
         delete_tasks.append(pulp_client.delete_by_href(product_repo.pulp_href))
     for product_distro in all_product_distros:
         delete_tasks.append(

--- a/alws/crud/products.py
+++ b/alws/crud/products.py
@@ -271,11 +271,12 @@ async def remove_product(
     for product_repo in db_product.repositories:
         # some repos from db can be absent in pulp
         # in case if you reset pulp db, but didn't reset non-pulp db
-        if all(
-                product_repo.name != product_distro['name'] for product_distro
-                in all_product_distros
-        ):
-            continue
+        #FIXME: uncomment after tests
+        # if all(
+        #         product_repo.name != product_distro['name'] for product_distro
+        #         in all_product_distros
+        # ):
+        #     continue
         delete_tasks.append(pulp_client.delete_by_href(product_repo.pulp_href))
     for product_distro in all_product_distros:
         delete_tasks.append(

--- a/alws/crud/repository.py
+++ b/alws/crud/repository.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session, selectinload
 
 from alws import models
 from alws.config import settings
-from alws.schemas import repository_schema, remote_schema
+from alws.schemas import remote_schema, repository_schema
 from alws.utils.pulp_client import PulpClient
 
 

--- a/alws/crud/repository.py
+++ b/alws/crud/repository.py
@@ -12,8 +12,8 @@ from alws.utils.pulp_client import PulpClient
 
 
 async def get_repositories(
-        db: Session,
-        repository_id: int = None,
+    db: Session,
+    repository_id: int = None,
 ) -> typing.List[models.Repository]:
     repo_q = select(models.Repository)
     if repository_id:
@@ -23,8 +23,8 @@ async def get_repositories(
 
 
 async def get_repositories_by_platform_name(
-        db: Session,
-        platform_name: str,
+    db: Session,
+    platform_name: str,
 ) -> typing.List[models.Repository]:
     result = await db.execute(
         select(models.Platform)
@@ -38,8 +38,8 @@ async def get_repositories_by_platform_name(
 
 
 async def create_repositories(
-        db: Session,
-        payload: typing.List[repository_schema.RepositoryCreate],
+    db: Session,
+    payload: typing.List[repository_schema.RepositoryCreate],
 ) -> typing.List[models.Repository]:
     # We need to update existing repositories instead of trying to create
     # new ones if they have the same parameters
@@ -79,8 +79,8 @@ async def create_repositories(
 
 
 async def create_repository(
-        db: Session,
-        payload: repository_schema.RepositoryCreate,
+    db: Session,
+    payload: repository_schema.RepositoryCreate,
 ) -> models.Repository:
     query = select(models.Repository).where(
         models.Repository.name == payload.name,
@@ -99,8 +99,8 @@ async def create_repository(
 
 
 async def search_repository(
-        db: Session,
-        payload: repository_schema.RepositorySearch,
+    db: Session,
+    payload: repository_schema.RepositorySearch,
 ) -> models.Repository:
     query = select(models.Repository)
     for key, value in payload.dict().items():
@@ -118,9 +118,9 @@ async def search_repository(
 
 
 async def update_repository(
-        db: Session,
-        repository_id: int,
-        payload: repository_schema.RepositoryUpdate,
+    db: Session,
+    repository_id: int,
+    payload: repository_schema.RepositoryUpdate,
 ) -> models.Repository:
     async with db.begin():
         db_repo = await db.execute(
@@ -141,16 +141,16 @@ async def delete_repository(db: Session, repository_id: int):
     async with db.begin():
         await db.execute(
             delete(models.Repository).where(
-            models.Repository.id == repository_id,
+                models.Repository.id == repository_id,
             )
         )
         await db.commit()
 
 
 async def add_to_platform(
-        db: Session,
-        platform_id: int,
-        repository_ids: typing.List[int],
+    db: Session,
+    platform_id: int,
+    repository_ids: typing.List[int],
 ) -> models.Platform:
     platform_result = await db.execute(
         select(models.Platform)
@@ -184,9 +184,9 @@ async def add_to_platform(
 
 
 async def remove_from_platform(
-        db: Session,
-        platform_id: int,
-        repository_ids: typing.List[int],
+    db: Session,
+    platform_id: int,
+    repository_ids: typing.List[int],
 ) -> models.Platform:
     await db.execute(
         delete(models.PlatformRepo).where(
@@ -205,8 +205,8 @@ async def remove_from_platform(
 
 
 async def create_repository_remote(
-        db: Session,
-        payload: remote_schema.RemoteCreate,
+    db: Session,
+    payload: remote_schema.RemoteCreate,
 ) -> models.RepositoryRemote:
     query = select(models.RepositoryRemote).where(
         models.RepositoryRemote.name == payload.name,
@@ -216,7 +216,7 @@ async def create_repository_remote(
     pulp_client = PulpClient(
         settings.pulp_host,
         settings.pulp_user,
-        settings.pulp_password
+        settings.pulp_password,
     )
     result = await db.execute(query)
     remote = result.scalars().first()
@@ -226,11 +226,15 @@ async def create_repository_remote(
     if pulp_remote:
         remote_href = pulp_remote['pulp_href']
         await pulp_client.update_rpm_remote(
-            remote_href, payload.url, remote_policy=payload.policy,
+            remote_href,
+            payload.url,
+            remote_policy=payload.policy,
         )
     else:
         remote_href = await pulp_client.create_rpm_remote(
-            payload.name, payload.url, remote_policy=payload.policy,
+            payload.name,
+            payload.url,
+            remote_policy=payload.policy,
         )
     if remote:
         return remote
@@ -247,9 +251,9 @@ async def create_repository_remote(
 
 
 async def update_repository_remote(
-        db: Session,
-        remote_id: int,
-        payload: remote_schema.RemoteUpdate,
+    db: Session,
+    remote_id: int,
+    payload: remote_schema.RemoteUpdate,
 ) -> models.RepositoryRemote:
     async with db.begin():
         result = await db.execute(
@@ -267,17 +271,19 @@ async def update_repository_remote(
 
 
 async def sync_repo_from_remote(
-        db: Session,
-        repository_id: int,
-        payload: repository_schema.RepositorySync,
-        wait_for_result: bool = False,
+    db: Session,
+    repository_id: int,
+    payload: repository_schema.RepositorySync,
+    wait_for_result: bool = False,
 ):
     async with db.begin():
         repository = select(models.Repository).get(repository_id)
         remote = select(models.RepositoryRemote).get(payload.remote_id)
 
     pulp_client = PulpClient(
-        settings.pulp_host, settings.pulp_user, settings.pulp_password,
+        settings.pulp_host,
+        settings.pulp_user,
+        settings.pulp_password,
     )
     return await pulp_client.sync_rpm_repo_from_remote(
         repository.pulp_href,

--- a/alws/schemas/remote_schema.py
+++ b/alws/schemas/remote_schema.py
@@ -26,3 +26,4 @@ class RemoteUpdate(BaseModel):
     name: typing.Optional[str]
     arch: typing.Optional[str]
     url: typing.Optional[str]
+    pulp_href: typing.Optional[str]

--- a/alws/schemas/remote_schema.py
+++ b/alws/schemas/remote_schema.py
@@ -2,7 +2,6 @@ import typing
 
 from pydantic import BaseModel
 
-
 __all__ = ['Remote', 'RemoteCreate', 'RemoteUpdate']
 
 

--- a/alws/schemas/repository_schema.py
+++ b/alws/schemas/repository_schema.py
@@ -3,8 +3,13 @@ import typing
 from pydantic import BaseModel
 
 
-__all__ = ['Repository', 'RepositoryCreate', 'RepositoryUpdate',
-           'RepositorySearch', 'RepositorySync']
+__all__ = [
+    'Repository',
+    'RepositoryCreate',
+    'RepositoryUpdate',
+    'RepositorySearch',
+    'RepositorySync',
+]
 
 
 class Repository(BaseModel):

--- a/alws/schemas/repository_schema.py
+++ b/alws/schemas/repository_schema.py
@@ -2,7 +2,6 @@ import typing
 
 from pydantic import BaseModel
 
-
 __all__ = [
     'Repository',
     'RepositoryCreate',

--- a/alws/schemas/repository_schema.py
+++ b/alws/schemas/repository_schema.py
@@ -51,6 +51,7 @@ class RepositoryUpdate(BaseModel):
     priority: int = 10
     production: typing.Optional[bool]
     export_path: typing.Optional[str]
+    pulp_href: typing.Optional[str]
     mock_enabled: bool = True
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,10 +25,7 @@ services:
     restart: always
 
   alts-celery:
-    image: alts-celery:latest
-    build:
-      dockerfile: Dockerfile.celery
-      context: ../alts
+    image: quay.io/almalinuxorg/alts-celery:latest
     environment:
       CELERY_CONFIG_PATH: "/celery_config.yaml"
       EXTERNAL_NETWORK: "albs-web-server_default"
@@ -50,10 +47,7 @@ services:
       - rabbitmq
 
   alts-scheduler:
-    image: alts-scheduler:latest
-    build:
-      dockerfile: Dockerfile.scheduler
-      context: ../alts
+    image: quay.io/almalinuxorg/alts-scheduler:latest
     ports:
       - "8082:8000"
     environment:
@@ -102,9 +96,6 @@ services:
     image: quay.io/almalinuxorg/task-queue:latest
     env_file:
       - vars.env
-    build:
-      dockerfile: Dockerfile.task-queue
-      context: .
     volumes:
       - "./alws:/code/alws"
       - "./tests:/code/tests"
@@ -126,9 +117,6 @@ services:
     image: quay.io/almalinuxorg/task-queue:latest
     env_file:
       - vars.env
-    build:
-      dockerfile: Dockerfile.task-queue
-      context: .
     volumes:
       - "./alws:/code/alws"
       - "./requirements.txt:/code/requirements.txt"
@@ -147,9 +135,6 @@ services:
     image: quay.io/almalinuxorg/task-queue:latest
     env_file:
       - vars.env
-    build:
-      dockerfile: Dockerfile.task-queue
-      context: .
     volumes:
       - "./alws:/code/alws"
       - "./requirements.txt:/code/requirements.txt"
@@ -168,9 +153,6 @@ services:
     image: quay.io/almalinuxorg/task-queue:latest
     env_file:
       - vars.env
-    build:
-      dockerfile: Dockerfile.task-queue
-      context: .
     volumes:
       - "./alws:/code/alws"
       - "./requirements.txt:/code/requirements.txt"
@@ -189,9 +171,6 @@ services:
     image: quay.io/almalinuxorg/task-queue:latest
     env_file:
       - vars.env
-    build:
-      dockerfile: Dockerfile.task-queue
-      context: .
     volumes:
       - "./alws:/code/alws"
       - "./requirements.txt:/code/requirements.txt"
@@ -205,9 +184,6 @@ services:
     image: quay.io/almalinuxorg/task-queue:latest
     env_file:
       - vars.env
-    build:
-      dockerfile: Dockerfile.task-queue
-      context: .
     volumes:
       - "./alws:/code/alws"
       - "./requirements.txt:/code/requirements.txt"
@@ -221,9 +197,6 @@ services:
     image: quay.io/almalinuxorg/task-queue:latest
     env_file:
       - vars.env
-    build:
-      dockerfile: Dockerfile.task-queue
-      context: .
     volumes:
       - "./alws:/code/alws"
       - "./requirements.txt:/code/requirements.txt"
@@ -279,7 +252,7 @@ services:
       - "../albs-sign-node/node-config:/home/alt/.config"
       - "~/.gnupg:/home/alt/.gnupg"
       - "../albs-sign-node/almalinux_sign_node.py:/sign-node/almalinux_sign_node.py"
-      - "../albs-sign-node:/sign-node/sign_node"
+      - "../albs-sign-node/sign_node:/sign-node/sign_node"
       - "../albs-sign-node/requirements.txt:/sign-node/requirements.txt"
     restart: on-failure
     command: "bash -c '/wait_for_it.sh web_server:8000 &&
@@ -347,6 +320,7 @@ services:
       - "../volumes/pulp/pulp_storage:/var/lib/pulp"
       - "../volumes/pulp/pgsql:/var/lib/pgsql"
       - "../volumes/pulp/containers:/var/lib/containers"
+      - "./pulp_init.sh:/usr/local/bin/pulp_init.sh"
     devices:
       - "/dev/fuse"
     restart: on-failure
@@ -382,6 +356,6 @@ services:
       - 3322:3322
       - 9497:9497
     volumes:
-      - "../volumes/immudb/data:/var/lib/immudb"
-      - "../volumes/immudb/config:/etc/immudb"
-      - "../volumes/immudb/logs:/var/log/immudb"
+      - "../volumes/immudb/data:/var/lib/immudb:Z"
+      - "../volumes/immudb/config:/etc/immudb:Z"
+      - "../volumes/immudb/logs:/var/log/immudb:Z"

--- a/pulp_init.sh
+++ b/pulp_init.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+(grep -qxF "listen_addresses = '*'" /var/lib/pgsql/data/postgresql.conf || echo "listen_addresses = '*'" >> /var/lib/pgsql/data/postgresql.conf) &&
+(grep -qxF "host all all 0.0.0.0/0 md5" /var/lib/pgsql/data/pg_hba.conf || echo "host all all 0.0.0.0/0 md5" >> /var/lib/pgsql/data/pg_hba.conf) &&
+(grep -qxF "host all all ::/0 md5" /var/lib/pgsql/data/pg_hba.conf || echo "host all all ::/0 md5" >> /var/lib/pgsql/data/pg_hba.conf) &&
+runuser postgres -c 'echo "ALTER USER postgres WITH PASSWORD '"'"'password'"'"';" | /usr/bin/psql'

--- a/scripts/bootstrap_repositories.py
+++ b/scripts/bootstrap_repositories.py
@@ -255,7 +255,7 @@ def main():
         for repo_info in repositories_data:
             logger.info(
                 "Creating repository from the following data: %s",
-                str(repo_info)
+                str(repo_info),
             )
             # If repository is not marked as production, do not remove `url` field
             repo_name = f'{repo_info["name"]}-{repo_info["arch"]}'

--- a/scripts/bootstrap_repositories.py
+++ b/scripts/bootstrap_repositories.py
@@ -11,10 +11,8 @@ import yaml
 from syncer import sync
 
 from alws import database
-from alws.crud import (
-    platform as pl_crud,
-    repository as repo_crud,
-)
+from alws.crud import platform as pl_crud
+from alws.crud import repository as repo_crud
 from alws.schemas import platform_schema, remote_schema, repository_schema
 from alws.utils.pulp_client import PulpClient
 

--- a/tests/fixtures/pulp.py
+++ b/tests/fixtures/pulp.py
@@ -436,7 +436,13 @@ def list_updateinfo_records(monkeypatch, pulp_updateinfos):
 @pytest.fixture
 def get_rpm_distros(monkeypatch):
     async def func(*args, **kwargs):
-        return [{"pulp_href": get_distros_href()}]
+        return [
+            {
+                "pulp_href": get_distros_href(),
+                "name": "rpm_distro_name",
+            },
+
+        ]
 
     monkeypatch.setattr(PulpClient, "get_rpm_distros", func)
 

--- a/tests/fixtures/pulp.py
+++ b/tests/fixtures/pulp.py
@@ -441,7 +441,6 @@ def get_rpm_distros(monkeypatch):
                 "pulp_href": get_distros_href(),
                 "name": "rpm_distro_name",
             },
-
         ]
 
     monkeypatch.setattr(PulpClient, "get_rpm_distros", func)


### PR DESCRIPTION
…use it puts sRPM to a wrong repo

- Remove non-needed section `build` from docker-compose.yml
- Mount pulp_init.sh to a pulp container. You can call the script and set up necessary direct access to pulp db
- Now bootstrap_repositories.py can set up necessary entities in pulp if you reset only pulp db