### PR TITLE
AlmaLinux/build-system#87: ALBS can't build multiplatform builds because it puts sRPM to a wrong repo

### DIFF
--- a/alws/build_planner.py
+++ b/alws/build_planner.py
@@ -39,6 +39,7 @@ class BuildPlanner:
         platform_flavors: typing.Optional[typing.List[int]],
         is_secure_boot: bool,
         module_build_index: typing.Optional[dict],
+        logger: logging.Logger,
     ):
         self._db = db
         self._gitea_client = GiteaClient(
@@ -47,6 +48,7 @@ class BuildPlanner:
         self._pulp_client = PulpClient(
             settings.pulp_host, settings.pulp_user, settings.pulp_password
         )
+        self.logger = logger
         self._build = build
         self._task_index = 0
         self._request_platforms = {}
@@ -132,11 +134,15 @@ class BuildPlanner:
             pulp_href=pulp_href,
             type=repo_type,
             debug=is_debug,
+            platform=platform,
         )
         self._build.repos.append(repo)
 
     async def create_log_repo(
-        self, repo_type: str, repo_prefix: str = 'build_logs'
+        self,
+        repo_type: str,
+        repo_prefix:
+        str = 'build_logs',
     ):
         repo_name = f'build-{self._build.id}-{repo_type}'
         repo_url, repo_href = await self._pulp_client.create_log_repo(
@@ -154,17 +160,23 @@ class BuildPlanner:
 
     async def init_build_repos(self):
         tasks = []
-
         # Add build log and test log repositories
         for repo_type, repo_prefix in (
             ('build_log', 'build_logs'),
             ('test_log', 'test_logs'),
         ):
             tasks.append(
-                self.create_log_repo(repo_type, repo_prefix=repo_prefix)
+                self.create_log_repo(
+                    repo_type, repo_prefix=repo_prefix
+                )
             )
 
         for platform in self._platforms:
+            self.logger.info(
+                'Create repos for platform "%s" with id "%s"',
+                platform.name,
+                platform.id,
+            )
             for arch in self._request_platforms[platform.name]:
                 tasks.append(self.create_build_repo(platform, arch, 'rpm'))
                 tasks.append(
@@ -406,7 +418,13 @@ class BuildPlanner:
                         module.add_rpm_artifact(artifact)
         return index
 
-    async def add_task(self, task: build_schema.BuildTaskRef):
+    async def add_task(
+            self,
+            task: typing.Union[
+                build_schema.BuildTaskRef,
+                build_schema.BuildTaskModuleRef,
+            ],
+    ):
         if isinstance(task, build_schema.BuildTaskRef) and not task.is_module:
             await self._add_single_ref(
                 models.BuildTaskRef(
@@ -436,9 +454,12 @@ class BuildPlanner:
             if devel_module:
                 module_templates.append(devel_module.render())
         else:
-            raw_refs, module_templates = await build_schema.get_module_refs(
-                task, self._platforms[0], self._platform_flavors
-            )
+            raw_refs = [
+                ref[0] for platform in self._platforms
+                for ref in await build_schema.get_module_refs(
+                    task, platform, self._platform_flavors
+                )
+            ]
         refs = [
             models.BuildTaskRef(
                 url=ref.url,
@@ -485,7 +506,8 @@ class BuildPlanner:
             if task.module_version:
                 module_version = int(task.module_version)
             mock_enabled_modules = mock_options.get('module_enable', [])[:]
-            # Take the first task mock_options as all tasks share the same mock_options
+            # Take the first task mock_options
+            # as all tasks share the same mock_options
             if task.refs:
                 mock_enabled_modules.extend(
                     task.refs[0].mock_options.get("module_enable", [])

--- a/alws/dramatiq/build.py
+++ b/alws/dramatiq/build.py
@@ -68,7 +68,8 @@ async def _start_build(build_id: int, build_request: build_schema.BuildCreate):
                 platforms=build_request.platforms,
                 platform_flavors=build_request.platform_flavors,
                 is_secure_boot=build_request.is_secure_boot,
-                module_build_index=module_build_index
+                module_build_index=module_build_index,
+                logger=logger,
             )
             for task in build_request.tasks:
                 await planner.add_task(task)

--- a/alws/routers/build_node.py
+++ b/alws/routers/build_node.py
@@ -51,7 +51,7 @@ async def build_done(
     return {"ok": True}
 
 
-@router.get(
+@router.post(
     "/get_task",
     response_model=typing.Optional[build_node_schema.Task],
 )

--- a/alws/schemas/build_schema.py
+++ b/alws/schemas/build_schema.py
@@ -338,12 +338,12 @@ def compare_module_data(
 async def _get_module_ref(
     component_name: str,
     modified_list: list,
-    platform_prefix_list: list,
+    platform_prefix_list: dict,
     module: ModuleWrapper,
     gitea_client: GiteaClient,
     devel_module: typing.Optional[ModuleWrapper],
     platform_packages_git: str,
-    beholder_data: typing.List[dict],
+    beholder_data: tuple[typing.Any],
 ):
     ref_prefix = platform_prefix_list['non_modified']
     if component_name in modified_list:

--- a/alws/utils/noarch.py
+++ b/alws/utils/noarch.py
@@ -51,6 +51,7 @@ async def save_noarch_packages(
     query = select(models.BuildTask).where(sqlalchemy.and_(
         models.BuildTask.build_id == build_task.build_id,
         models.BuildTask.index == build_task.index,
+        models.BuildTask.platform_id == build_task.platform_id,
     )).options(
         selectinload(models.BuildTask.artifacts),
         selectinload(models.BuildTask.build).selectinload(models.Build.repos),


### PR DESCRIPTION
- Select only right rpm repositories by a platform while processing a build task artifacts
- Update built_srpm_url only for the build tasks of one platform
- HTTP-method for route `get_task` is changed from GET to POST, because it sends a request's body (because https://github.com/swagger-api/swagger-ui/issues/8682 & RFC7231)
- Some typing is changed for better autocompleting and linting
- Select and put noarch packages only among the build tasks of one platform
- Create raw_refs per each existing platform, not only first platform from the list