### PR TITLE
AlmaLinux/build-system#87: ALBS can't build multiplatform builds beca…

### DIFF
--- a/alws/build_planner.py
+++ b/alws/build_planner.py
@@ -452,9 +452,9 @@ class BuildPlanner:
                 module_templates.append(devel_module.render())
         else:
             raw_refs = [
-                ref[0]
+                ref
                 for platform in self._platforms
-                for ref in await build_schema.get_module_refs(
+                for ref, *_ in await build_schema.get_module_refs(
                     task, platform, self._platform_flavors
                 )
             ]

--- a/alws/build_planner.py
+++ b/alws/build_planner.py
@@ -141,8 +141,7 @@ class BuildPlanner:
     async def create_log_repo(
         self,
         repo_type: str,
-        repo_prefix:
-        str = 'build_logs',
+        repo_prefix: str = 'build_logs',
     ):
         repo_name = f'build-{self._build.id}-{repo_type}'
         repo_url, repo_href = await self._pulp_client.create_log_repo(
@@ -166,9 +165,7 @@ class BuildPlanner:
             ('test_log', 'test_logs'),
         ):
             tasks.append(
-                self.create_log_repo(
-                    repo_type, repo_prefix=repo_prefix
-                )
+                self.create_log_repo(repo_type, repo_prefix=repo_prefix)
             )
 
         for platform in self._platforms:
@@ -419,11 +416,11 @@ class BuildPlanner:
         return index
 
     async def add_task(
-            self,
-            task: typing.Union[
-                build_schema.BuildTaskRef,
-                build_schema.BuildTaskModuleRef,
-            ],
+        self,
+        task: typing.Union[
+            build_schema.BuildTaskRef,
+            build_schema.BuildTaskModuleRef,
+        ],
     ):
         if isinstance(task, build_schema.BuildTaskRef) and not task.is_module:
             await self._add_single_ref(
@@ -455,7 +452,8 @@ class BuildPlanner:
                 module_templates.append(devel_module.render())
         else:
             raw_refs = [
-                ref[0] for platform in self._platforms
+                ref[0]
+                for platform in self._platforms
                 for ref in await build_schema.get_module_refs(
                     task, platform, self._platform_flavors
                 )

--- a/alws/build_planner.py
+++ b/alws/build_planner.py
@@ -39,6 +39,7 @@ class BuildPlanner:
         platform_flavors: typing.Optional[typing.List[int]],
         is_secure_boot: bool,
         module_build_index: typing.Optional[dict],
+        logger: logging.Logger,
     ):
         self._db = db
         self._gitea_client = GiteaClient(
@@ -47,6 +48,7 @@ class BuildPlanner:
         self._pulp_client = PulpClient(
             settings.pulp_host, settings.pulp_user, settings.pulp_password
         )
+        self.logger = logger
         self._build = build
         self._task_index = 0
         self._request_platforms = {}
@@ -132,11 +134,15 @@ class BuildPlanner:
             pulp_href=pulp_href,
             type=repo_type,
             debug=is_debug,
+            platform=platform,
         )
         self._build.repos.append(repo)
 
     async def create_log_repo(
-        self, repo_type: str, repo_prefix: str = 'build_logs'
+        self,
+        repo_type: str,
+        repo_prefix:
+        str = 'build_logs',
     ):
         repo_name = f'build-{self._build.id}-{repo_type}'
         repo_url, repo_href = await self._pulp_client.create_log_repo(
@@ -154,17 +160,23 @@ class BuildPlanner:
 
     async def init_build_repos(self):
         tasks = []
-
         # Add build log and test log repositories
         for repo_type, repo_prefix in (
             ('build_log', 'build_logs'),
             ('test_log', 'test_logs'),
         ):
             tasks.append(
-                self.create_log_repo(repo_type, repo_prefix=repo_prefix)
+                self.create_log_repo(
+                    repo_type, repo_prefix=repo_prefix
+                )
             )
 
         for platform in self._platforms:
+            self.logger.info(
+                'Create repos for platform "%s" with id "%s"',
+                platform.name,
+                platform.id,
+            )
             for arch in self._request_platforms[platform.name]:
                 tasks.append(self.create_build_repo(platform, arch, 'rpm'))
                 tasks.append(
@@ -406,7 +418,13 @@ class BuildPlanner:
                         module.add_rpm_artifact(artifact)
         return index
 
-    async def add_task(self, task: build_schema.BuildTaskRef):
+    async def add_task(
+            self,
+            task: typing.Union[
+                build_schema.BuildTaskRef,
+                build_schema.BuildTaskModuleRef,
+            ],
+    ):
         if isinstance(task, build_schema.BuildTaskRef) and not task.is_module:
             await self._add_single_ref(
                 models.BuildTaskRef(
@@ -436,9 +454,12 @@ class BuildPlanner:
             if devel_module:
                 module_templates.append(devel_module.render())
         else:
-            raw_refs, module_templates = await build_schema.get_module_refs(
-                task, self._platforms[0], self._platform_flavors
-            )
+            raw_refs = [
+                ref[0] for platform in self._platforms
+                for ref in await build_schema.get_module_refs(
+                    task, platform, self._platform_flavors
+                )
+            ]
         refs = [
             models.BuildTaskRef(
                 url=ref.url,
@@ -485,7 +506,8 @@ class BuildPlanner:
             if task.module_version:
                 module_version = int(task.module_version)
             mock_enabled_modules = mock_options.get('module_enable', [])[:]
-            # Take the first task mock_options as all tasks share the same mock_options
+            # Take the first task mock_options
+            # as all tasks share the same mock_options
             if task.refs:
                 mock_enabled_modules.extend(
                     task.refs[0].mock_options.get("module_enable", [])

--- a/alws/crud/build_node.py
+++ b/alws/crud/build_node.py
@@ -587,7 +587,7 @@ async def __process_build_task_artifacts(
                     models.Repository.type == 'rpm',
                 )
             )
-         )
+        )
         .scalars()
         .all()
     )

--- a/alws/dramatiq/build.py
+++ b/alws/dramatiq/build.py
@@ -50,11 +50,11 @@ async def _start_build(build_id: int, build_request: build_schema.BuildCreate):
         with SyncSession() as db, db.begin():
             platforms = (
                 db.execute(
-                        select(models.Platform).where(
-                            models.Platform.name.in_(
-                                [p.name for p in build_request.platforms]
-                            )
+                    select(models.Platform).where(
+                        models.Platform.name.in_(
+                            [p.name for p in build_request.platforms]
                         )
+                    )
                 )
                 .scalars()
                 .all()
@@ -62,8 +62,7 @@ async def _start_build(build_id: int, build_request: build_schema.BuildCreate):
             for platform in platforms:
                 db.execute(
                     update(models.Platform)
-                    .where(
-                    models.Platform.id == platform.id)
+                    .where(models.Platform.id == platform.id)
                     .values(
                         {
                             'module_build_index': models.Platform.module_build_index
@@ -110,7 +109,8 @@ async def _build_done(request: build_node_schema.BuildDone):
             logger.exception(
                 'Unable to complete safe_build_done for build task "%d", '
                 'marking it as failed.\nError: %s',
-                request.task_id, str(e)
+                request.task_id,
+                str(e),
             )
             build_task = (
                 (
@@ -144,7 +144,8 @@ async def _build_done(request: build_node_schema.BuildDone):
             except Exception as e:
                 logger.exception(
                     'Unable to create test tasks for build "%d". Error: %s',
-                    build_id, str(e)
+                    build_id,
+                    str(e),
                 )
             build_id = await _get_build_id(db, request.task_id)
             await db.execute(
@@ -179,9 +180,7 @@ async def _check_build_and_completed_tasks(
             await db.execute(
                 select(func.count())
                 .select_from(models.BuildTask)
-                .where(
-                    models.BuildTask.build_id == build_id
-                )
+                .where(models.BuildTask.build_id == build_id)
             )
         ).scalar()
 
@@ -196,7 +195,7 @@ async def _check_build_and_completed_tasks(
                             BuildTaskStatus.IDLE,
                             BuildTaskStatus.STARTED,
                         ]
-                    )
+                    ),
                 )
             )
         ).scalar()
@@ -234,7 +233,7 @@ def start_build(build_id: int, build_request: Dict[str, Any]):
         NoarchProcessingError,
         RepositoryAddError,
         SrpmProvisionError,
-    )
+    ),
 )
 def build_done(request: Dict[str, Any]):
     parsed_build = build_node_schema.BuildDone(**request)

--- a/alws/dramatiq/build.py
+++ b/alws/dramatiq/build.py
@@ -68,7 +68,8 @@ async def _start_build(build_id: int, build_request: build_schema.BuildCreate):
                 platforms=build_request.platforms,
                 platform_flavors=build_request.platform_flavors,
                 is_secure_boot=build_request.is_secure_boot,
-                module_build_index=module_build_index
+                module_build_index=module_build_index,
+                logger=logger,
             )
             for task in build_request.tasks:
                 await planner.add_task(task)

--- a/alws/dramatiq/build.py
+++ b/alws/dramatiq/build.py
@@ -1,8 +1,8 @@
 import datetime
+import logging
 from typing import Dict, Any
 
 import dramatiq
-import logging
 
 from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -10,8 +10,13 @@ from sqlalchemy.future import select
 from sqlalchemy.sql.expression import func
 
 from alws import models
+from alws.build_planner import BuildPlanner
 from alws.constants import DRAMATIQ_TASK_TIMEOUT, BuildTaskStatus
-from alws.crud import build_node as build_node_crud, test
+from alws.crud import build_node as build_node_crud
+from alws.crud import test
+from alws.database import SyncSession
+from alws.dependencies import get_db
+from alws.dramatiq import event_loop
 from alws.errors import (
     ArtifactConversionError,
     ModuleUpdateError,
@@ -20,11 +25,7 @@ from alws.errors import (
     RepositoryAddError,
     SrpmProvisionError,
 )
-from alws.build_planner import BuildPlanner
 from alws.schemas import build_schema, build_node_schema
-from alws.database import SyncSession
-from alws.dependencies import get_db
-from alws.dramatiq import event_loop
 
 __all__ = ['start_build', 'build_done']
 

--- a/alws/dramatiq/build.py
+++ b/alws/dramatiq/build.py
@@ -1,9 +1,8 @@
 import datetime
 import logging
-from typing import Dict, Any
+from typing import Any, Dict
 
 import dramatiq
-
 from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
@@ -25,7 +24,7 @@ from alws.errors import (
     RepositoryAddError,
     SrpmProvisionError,
 )
-from alws.schemas import build_schema, build_node_schema
+from alws.schemas import build_node_schema, build_schema
 
 __all__ = ['start_build', 'build_done']
 

--- a/alws/dramatiq/build.py
+++ b/alws/dramatiq/build.py
@@ -204,7 +204,7 @@ async def _check_build_and_completed_tasks(
 
 
 async def _all_build_tasks_completed(
-        db: AsyncSession, build_task_id: int
+    db: AsyncSession, build_task_id: int
 ) -> bool:
     build_id = await _get_build_id(db, build_task_id)
     all_completed = await _check_build_and_completed_tasks(db, build_id)

--- a/alws/routers/build_node.py
+++ b/alws/routers/build_node.py
@@ -51,7 +51,7 @@ async def build_done(
     return {"ok": True}
 
 
-@router.get(
+@router.post(
     "/get_task",
     response_model=typing.Optional[build_node_schema.Task],
 )

--- a/alws/schemas/build_schema.py
+++ b/alws/schemas/build_schema.py
@@ -307,7 +307,7 @@ async def get_module_data_from_beholder(
 
 def compare_module_data(
     component_name: str,
-    beholder_data: typing.List[dict],
+    beholder_data: tuple[typing.Any],
     tag_name: str,
 ) -> typing.List[dict]:
     pkgs_to_add = []

--- a/alws/schemas/build_schema.py
+++ b/alws/schemas/build_schema.py
@@ -338,12 +338,12 @@ def compare_module_data(
 async def _get_module_ref(
     component_name: str,
     modified_list: list,
-    platform_prefix_list: list,
+    platform_prefix_list: dict,
     module: ModuleWrapper,
     gitea_client: GiteaClient,
     devel_module: typing.Optional[ModuleWrapper],
     platform_packages_git: str,
-    beholder_data: typing.List[dict],
+    beholder_data: tuple[typing.Any],
 ):
     ref_prefix = platform_prefix_list['non_modified']
     if component_name in modified_list:

--- a/alws/utils/noarch.py
+++ b/alws/utils/noarch.py
@@ -20,8 +20,7 @@ __all__ = [
 
 
 async def get_noarch_packages(
-    db: AsyncSession,
-    build_task_ids: typing.List[int]
+    db: AsyncSession, build_task_ids: typing.List[int]
 ) -> typing.Tuple[dict, dict]:
     query = select(models.BuildTaskArtifact).where(
         sqlalchemy.and_(
@@ -60,7 +59,8 @@ async def save_noarch_packages(
                 models.BuildTask.index == build_task.index,
                 models.BuildTask.platform_id == build_task.platform_id,
             )
-        ).options(
+        )
+        .options(
             selectinload(models.BuildTask.artifacts),
             selectinload(models.BuildTask.build).selectinload(
                 models.Build.repos
@@ -153,7 +153,7 @@ async def save_noarch_packages(
             pulp_client.modify_repository(
                 repo_href,
                 add=content_dict['add'],
-                remove=content_dict['remove']
+                remove=content_dict['remove'],
             )
             for repo_href, content_dict in repos_to_update.items()
         )

--- a/alws/utils/noarch.py
+++ b/alws/utils/noarch.py
@@ -23,19 +23,23 @@ async def get_noarch_packages(
     db: AsyncSession,
     build_task_ids: typing.List[int]
 ) -> typing.Tuple[dict, dict]:
-    query = select(models.BuildTaskArtifact).where(sqlalchemy.and_(
-        models.BuildTaskArtifact.build_task_id.in_(build_task_ids),
-        models.BuildTaskArtifact.type == 'rpm',
-        models.BuildTaskArtifact.name.like('%.noarch.%'),
-    ))
+    query = select(models.BuildTaskArtifact).where(
+        sqlalchemy.and_(
+            models.BuildTaskArtifact.build_task_id.in_(build_task_ids),
+            models.BuildTaskArtifact.type == 'rpm',
+            models.BuildTaskArtifact.name.like('%.noarch.%'),
+        )
+    )
     db_artifacts = await db.execute(query)
     db_artifacts = db_artifacts.scalars().all()
     noarch_packages = {}
     debug_noarch_packages = {}
     for artifact in db_artifacts:
         if '-debuginfo-' in artifact.name or '-debugsource-' in artifact.name:
-            debug_noarch_packages[artifact.name] = (artifact.href,
-                                                    artifact.cas_hash)
+            debug_noarch_packages[artifact.name] = (
+                artifact.href,
+                artifact.cas_hash,
+            )
             continue
         noarch_packages[artifact.name] = (artifact.href, artifact.cas_hash)
 
@@ -48,25 +52,33 @@ async def save_noarch_packages(
     build_task: models.BuildTask,
 ):
     new_binary_rpms = []
-    query = select(models.BuildTask).where(sqlalchemy.and_(
-        models.BuildTask.build_id == build_task.build_id,
-        models.BuildTask.index == build_task.index,
-        models.BuildTask.platform_id == build_task.platform_id,
-    )).options(
-        selectinload(models.BuildTask.artifacts),
-        selectinload(models.BuildTask.build).selectinload(models.Build.repos),
+    query = (
+        select(models.BuildTask)
+        .where(
+            sqlalchemy.and_(
+                models.BuildTask.build_id == build_task.build_id,
+                models.BuildTask.index == build_task.index,
+                models.BuildTask.platform_id == build_task.platform_id,
+            )
+        ).options(
+            selectinload(models.BuildTask.artifacts),
+            selectinload(models.BuildTask.build).selectinload(
+                models.Build.repos
+            ),
+        )
     )
     build_tasks = await db.execute(query)
     build_tasks = build_tasks.scalars().all()
     if not all(
-            BuildTaskStatus.is_finished(task.status)
-            for task in build_tasks):
+        BuildTaskStatus.is_finished(task.status) for task in build_tasks
+    ):
         return new_binary_rpms
 
     logging.info("Start processing noarch packages")
     build_task_ids = [task.id for task in build_tasks]
     noarch_packages, debug_noarch_packages = await get_noarch_packages(
-        db, build_task_ids)
+        db, build_task_ids
+    )
     if not any((noarch_packages, debug_noarch_packages)):
         logging.info("Noarch packages doesn't found")
         return new_binary_rpms
@@ -77,8 +89,7 @@ async def save_noarch_packages(
     debug_hrefs_to_add = [href for href, _ in debug_noarch_packages.values()]
 
     for task in build_tasks:
-        if task.status in (BuildTaskStatus.FAILED,
-                           BuildTaskStatus.EXCLUDED):
+        if task.status in (BuildTaskStatus.FAILED, BuildTaskStatus.EXCLUDED):
             continue
         noarch = copy.deepcopy(noarch_packages)
         debug_noarch = copy.deepcopy(debug_noarch_packages)
@@ -117,8 +128,11 @@ async def save_noarch_packages(
                 new_binary_rpms.append(binary_rpm)
 
         for repo in build_task.build.repos:
-            if (repo.arch == 'src' or repo.type != 'rpm'
-                    or repo.arch != task.arch):
+            if (
+                repo.arch == 'src'
+                or repo.type != 'rpm'
+                or repo.arch != task.arch
+            ):
                 continue
             repo_href = repo.pulp_href
             add_content = hrefs_to_add
@@ -134,12 +148,16 @@ async def save_noarch_packages(
     db.add_all(new_noarch_artifacts)
     await db.flush()
 
-    await asyncio.gather(*(
-        pulp_client.modify_repository(
-            repo_href, add=content_dict['add'],
-            remove=content_dict['remove'])
-        for repo_href, content_dict in repos_to_update.items()
-    ))
+    await asyncio.gather(
+        *(
+            pulp_client.modify_repository(
+                repo_href,
+                add=content_dict['add'],
+                remove=content_dict['remove']
+            )
+            for repo_href, content_dict in repos_to_update.items()
+        )
+    )
 
     logging.info("Noarch packages processing is finished")
     return new_binary_rpms

--- a/alws/utils/noarch.py
+++ b/alws/utils/noarch.py
@@ -62,9 +62,7 @@ async def save_noarch_packages(
         .options(
             selectinload(models.BuildTask.artifacts),
             selectinload(models.BuildTask.build).selectinload(
-                models.Build.repos.and_(
-                    models.Repository.platform_id == build_task.platform_id,
-                )
+                models.Build.repos
             ),
         )
     )
@@ -133,6 +131,7 @@ async def save_noarch_packages(
                 repo.arch == 'src'
                 or repo.type != 'rpm'
                 or repo.arch != task.arch
+                or repo.platform_id != task.platform_id
             ):
                 continue
             repo_href = repo.pulp_href

--- a/alws/utils/noarch.py
+++ b/alws/utils/noarch.py
@@ -12,7 +12,6 @@ from alws import models
 from alws.constants import BuildTaskStatus
 from alws.utils.pulp_client import PulpClient
 
-
 __all__ = [
     'get_noarch_packages',
     'save_noarch_packages',

--- a/alws/utils/noarch.py
+++ b/alws/utils/noarch.py
@@ -62,7 +62,9 @@ async def save_noarch_packages(
         .options(
             selectinload(models.BuildTask.artifacts),
             selectinload(models.BuildTask.build).selectinload(
-                models.Build.repos
+                models.Build.repos.and_(
+                    models.Repository.platform_id == build_task.platform_id,
+                )
             ),
         )
     )

--- a/alws/utils/noarch.py
+++ b/alws/utils/noarch.py
@@ -51,6 +51,7 @@ async def save_noarch_packages(
     query = select(models.BuildTask).where(sqlalchemy.and_(
         models.BuildTask.build_id == build_task.build_id,
         models.BuildTask.index == build_task.index,
+        models.BuildTask.platform_id == build_task.platform_id,
     )).options(
         selectinload(models.BuildTask.artifacts),
         selectinload(models.BuildTask.build).selectinload(models.Build.repos),


### PR DESCRIPTION
…use it puts sRPM to a wrong repo

- Select only right rpm repositories by a platform while processing a build task artifacts
- Update built_srpm_url only for the build tasks of one platform
- HTTP-method for route `get_task` is changed from GET to POST, because it sends a request's body (because https://github.com/swagger-api/swagger-ui/issues/8682 & RFC7231)
- Some typing is changed for better autocompleting and linting
- Select and put noarch packages only among the build tasks of one platform
- Create raw_refs per each existing platform, not only first platform from the list