### PR TITLE
AlmaLinux/build-system#113: ALBS can't release/add a multi-platform b…

### DIFF
--- a/alws/crud/sign_task.py
+++ b/alws/crud/sign_task.py
@@ -651,7 +651,7 @@ async def complete_sign_task(
                     repo_unique_key = RepoUniqueKey(
                         arch=arch,
                         debug=debug,
-                        platform_id=rpms_per_platforms_mapping[pkg_name]
+                        platform_id=rpms_per_platforms_mapping[pkg_name],
                     )
                     repo = repo_mapping[repo_unique_key]
                     packages_to_add[repo.pulp_href].append(new_href)

--- a/alws/dramatiq/products.py
+++ b/alws/dramatiq/products.py
@@ -168,7 +168,8 @@ async def set_platform_for_products_repos(
         f"{product.owner.username}-{product.name}-{platform.name.lower()}-"
         f"{repo.arch}-{repo_debug_dict[repo.debug]}": platform
         for repo in product.repositories
-        for platform in product.platforms if repo.type != 'sign_key'
+        for platform in product.platforms
+        if repo.type != 'sign_key'
     }
     # we do nothing if all repos have platform
     if all(repo.platform for repo in product.repositories):

--- a/alws/routers/releases.py
+++ b/alws/routers/releases.py
@@ -136,21 +136,26 @@ async def delete_release(
     """
 
     async with db.begin():
-        release = (await db.execute(
-            select(models.Release)
-            .where(
-                models.Release.id == release_id,
-                models.Release.status == ReleaseStatus.SCHEDULED,
+        release = (
+            (
+                await db.execute(
+                    select(models.Release).where(
+                        models.Release.id == release_id,
+                        models.Release.status == ReleaseStatus.SCHEDULED,
+                    )
+                )
             )
-        )).scalars().first()
+            .scalars()
+            .first()
+        )
         if release is None:
             return {
                 'message':
-                f'There is no scheduled release plant with ID "{release_id}"'
+                f'There is no scheduled release plant with ID "{release_id}"',
             }
         else:
             await db.delete(release)
             return {
                 'message':
-                    f'Scheduled release with ID "{release_id}" is removed'
+                f'Scheduled release with ID "{release_id}" is removed',
             }

--- a/alws/routers/releases.py
+++ b/alws/routers/releases.py
@@ -1,7 +1,7 @@
 import typing
 
 from fastapi import APIRouter, Depends
-from sqlalchemy import update
+from sqlalchemy import update, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from alws import models
@@ -120,3 +120,37 @@ async def revert_db_release(
         )
     revert_release.send(release_id, user.id)
     return {"message": "Release plan revert has been started"}
+
+
+@router.delete(
+    '/{release_id}/delete',
+    response_model=release_schema.ReleaseCommitResult,
+)
+async def delete_release(
+    release_id: int,
+    db: AsyncSession = Depends(get_db),
+    user: models.User = Depends(get_current_user),
+):
+    """
+    Delete only a scheduled release
+    """
+
+    async with db.begin():
+        release = (await db.execute(
+            select(models.Release)
+            .where(
+                models.Release.id == release_id,
+                models.Release.status == ReleaseStatus.SCHEDULED,
+            )
+        )).scalars().first()
+        if release is None:
+            return {
+                'message':
+                f'There is no scheduled release plant with ID "{release_id}"'
+            }
+        else:
+            await db.delete(release)
+            return {
+                'message':
+                    f'Scheduled release with ID "{release_id}" is removed'
+            }

--- a/tests/fixtures/builds.py
+++ b/tests/fixtures/builds.py
@@ -122,6 +122,13 @@ def modular_build_payload() -> typing.Dict[str, typing.Any]:
                 "parallel_mode_enabled": True,
             }
         ],
+        "repos": [
+            {
+                'name': 'test-repos-8',
+                'type': 'rpm',
+                'platform_id': 1,
+            }
+        ],
         "tasks": [
             {
                 "refs": [

--- a/tests/test_api/test_releases.py
+++ b/tests/test_api/test_releases.py
@@ -1,3 +1,5 @@
+import typing
+
 from sqlalchemy import select, or_
 from sqlalchemy.ext.asyncio import AsyncSession
 


### PR DESCRIPTION
…uild to a product

- Select a proper repo for a package (by arch, type of package (debug or not) and platform ID) while getting/completing a sign task
- Exclude a repo with sign_key while selecting a product's repos
- It's added endpoint to delete only scheduled release plan (for test and following prod purposes)
- Select packages for only one platform while preparing a release plan