### PR TITLE
MQTT now listens on all interfaces

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -333,6 +333,8 @@ services:
     image: eclipse-mosquitto:2.0
     ports:
       - "11883:1883"
+    volumes:
+      - "./mosquitto-no-auth.conf:/mosquitto/config/mosquitto.conf"
 
   redis:
     image: redis

--- a/mosquitto-no-auth.conf
+++ b/mosquitto-no-auth.conf
@@ -1,0 +1,5 @@
+# This is a Mosquitto configuration file that creates a listener on port 1883
+# that allows unauthenticated access.
+
+listener 1883 0.0.0.0
+allow_anonymous true


### PR DESCRIPTION
Added config file for mosquitto service so it will listnen on all inerfaces.

Without this setting git-listener cant connect to it Related to https://github.com/AlmaLinux/build-system/issues/132