### PR TITLE
Required changes after adding albs user for albs_frontend container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -250,8 +250,8 @@ services:
       context: ../albs-frontend
     command: bash -c "npm install && npm run dev"
     volumes:
-      - "../albs-frontend:/code"
-      - "../node_modules:/code/node_modules"
+      - "../albs-frontend:/home/albs/code"
+      - "frontend_node_modules:/code/node_modules"
     restart: on-failure
     depends_on:
       - web_server
@@ -406,3 +406,6 @@ services:
       - "../volumes/immudb/data:/var/lib/immudb:Z"
       - "../volumes/immudb/config:/etc/immudb:Z"
       - "../volumes/immudb/logs:/var/log/immudb:Z"
+
+volumes:
+  frontend_node_modules:


### PR DESCRIPTION
 1. node_modules dir now mounts as named volume
 2. changed bind mount for code since container now runs as albs user

Related to
- https://github.com/AlmaLinux/build-system/issues/131
- https://github.com/AlmaLinux/albs-frontend/pull/392