### PR TITLE
Add retry to git-cacher for robustness

### DIFF
--- a/alws/scripts/git_cacher/git_cacher.py
+++ b/alws/scripts/git_cacher/git_cacher.py
@@ -100,13 +100,17 @@ async def main():
     logger = setup_logger()
     redis_client = aioredis.from_url(config.redis_url)
     gitea_client = GiteaClient(config.gitea_host, logger)
+    wait = 600
     while True:
         logger.info('Checking cache for updates')
         await asyncio.gather(
             run(config, logger, redis_client, gitea_client, 'rpms'),
             run(config, logger, redis_client, gitea_client, 'modules'),
         )
-        await asyncio.sleep(600)
+        logger.info(
+            f'Cache has been updated, waiting for {wait} sec for next update'
+        )
+        await asyncio.sleep(wait)
 
 
 if __name__ == '__main__':

--- a/alws/utils/gitea.py
+++ b/alws/utils/gitea.py
@@ -1,7 +1,7 @@
 import asyncio
+import logging
 import typing
 import urllib.parse
-import logging
 
 import aiohttp
 

--- a/alws/utils/gitea.py
+++ b/alws/utils/gitea.py
@@ -6,7 +6,6 @@ import logging
 import aiohttp
 
 
-
 class ModulesYamlNotFoundError(Exception):
     pass
 
@@ -20,8 +19,10 @@ def modules_yaml_path_from_url(url: str, ref: str, ref_type: str) -> str:
     elif ref_type == 'git_branch':
         ref_type = 'branch'
     # TODO: use config hostname, instead of https://git.almalinux.org
-    return (f'https://git.almalinux.org/modules/{repo_name}'
-            f'/raw/{ref_type}/{ref}/SOURCES/modulemd.src.txt')
+    return (
+        f'https://git.almalinux.org/modules/{repo_name}'
+        f'/raw/{ref_type}/{ref}/SOURCES/modulemd.src.txt'
+    )
 
 
 async def download_modules_yaml(url: str, ref: str, ref_type: str) -> str:
@@ -39,7 +40,6 @@ async def download_modules_yaml(url: str, ref: str, ref_type: str) -> str:
 
 
 class GiteaClient:
-
     def __init__(self, host: str, log: logging.Logger):
         self.host = host
         self.log = log
@@ -83,10 +83,7 @@ class GiteaClient:
         # This is max gitea limit, default is 30
         items_per_page = 50
         while True:
-            payload = {
-                'limit': items_per_page,
-                'page': page
-            }
+            payload = {'limit': items_per_page, 'page': page}
             response = await self.make_request(endpoint, payload)
             items.extend(response)
             if len(response) < items_per_page:


### PR DESCRIPTION
Resolves: https://github.com/AlmaLinux/build-system/issues/183


Now it retries 5 times at maximum when errors occurred.
```
2024-02-09 08:57:25,080 [gitea-cacher:DEBUG] - Attempt to request [#1/5] https://git.almalinux.org/api/v1/orgs/rpms/repos, with params: {'limit': 50, 'page': 14}
2024-02-09 08:57:27,214 [gitea-cacher:DEBUG] - Attempt to request [#1/5] https://git.almalinux.org/api/v1/orgs/rpms/repos, with params: {'limit': 50, 'page': 15}
2024-02-09 08:58:27,599 [gitea-cacher:ERROR] - Error during making request: Server disconnected, https://git.almalinux.org/api/v1/orgs/rpms/repos, {'limit': 50, 'page': 15}
2024-02-09 08:58:27,599 [gitea-cacher:DEBUG] - Retrying attempt [#1/5] in 2 seconds: https://git.almalinux.org/api/v1/orgs/rpms/repos, with params: {'limit': 50, 'page': 15}
2024-02-09 08:58:29,602 [gitea-cacher:DEBUG] - Attempt to request [#2/5] https://git.almalinux.org/api/v1/orgs/rpms/repos, with params: {'limit': 50, 'page': 15}
```