### PR TITLE
Migrate Sqlalcehmy to the v2

### DIFF
--- a/alws/database.py
+++ b/alws/database.py
@@ -2,7 +2,11 @@
 # author: Vyacheslav Potoropin <vpotoropin@almalinux.org>
 # created: 2021-06-22
 from sqlalchemy import MetaData, create_engine
-from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.ext.asyncio import (
+    AsyncAttrs,
+    AsyncSession,
+    create_async_engine,
+)
 from sqlalchemy.orm import DeclarativeBase, scoped_session, sessionmaker
 from sqlalchemy.pool import NullPool
 
@@ -19,7 +23,7 @@ sync_engine = create_engine(
 )
 
 
-class Base(DeclarativeBase):
+class Base(AsyncAttrs, DeclarativeBase):
     __allow_unmapped__ = True
     metadata = MetaData()
 
@@ -29,7 +33,7 @@ Session = sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
 SyncSession = scoped_session(sync_session_factory)
 
 
-class PulpBase(DeclarativeBase):
+class PulpBase(AsyncAttrs, DeclarativeBase):
     __allow_unmapped__ = True
 
 

--- a/alws/database.py
+++ b/alws/database.py
@@ -1,10 +1,9 @@
 # -*- mode:python; coding:utf-8; -*-
 # author: Vyacheslav Potoropin <vpotoropin@almalinux.org>
 # created: 2021-06-22
-from sqlalchemy import create_engine
+from sqlalchemy import MetaData, create_engine
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import scoped_session, sessionmaker
+from sqlalchemy.orm import DeclarativeBase, scoped_session, sessionmaker
 from sqlalchemy.pool import NullPool
 
 from alws.config import settings
@@ -20,16 +19,20 @@ sync_engine = create_engine(
 )
 
 
-class Base:
+class Base(DeclarativeBase):
     __allow_unmapped__ = True
+    metadata = MetaData()
 
 
-Base = declarative_base(cls=Base)
 sync_session_factory = sessionmaker(sync_engine, expire_on_commit=False)
 Session = sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
 SyncSession = scoped_session(sync_session_factory)
 
-PulpBase = declarative_base(cls=Base)
+
+class PulpBase(DeclarativeBase):
+    __allow_unmapped__ = True
+
+
 pulp_engine = create_engine(
     settings.pulp_database_url, pool_pre_ping=True, pool_recycle=3600
 )

--- a/alws/database.py
+++ b/alws/database.py
@@ -18,12 +18,18 @@ engine = create_async_engine(DATABASE_URL, poolclass=NullPool, echo_pool=True)
 sync_engine = create_engine(
     settings.sync_database_url, pool_pre_ping=True, pool_recycle=3600
 )
-Base = declarative_base()
+
+
+class Base:
+    __allow_unmapped__ = True
+
+
+Base = declarative_base(cls=Base)
 sync_session_factory = sessionmaker(sync_engine, expire_on_commit=False)
 Session = sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
 SyncSession = scoped_session(sync_session_factory)
 
-PulpBase = declarative_base()
+PulpBase = declarative_base(cls=Base)
 pulp_engine = create_engine(
     settings.pulp_database_url, pool_pre_ping=True, pool_recycle=3600
 )

--- a/alws/models.py
+++ b/alws/models.py
@@ -230,9 +230,7 @@ PlatformRoleMapping = sqlalchemy.Table(
 class Platform(PermissionsMixin, Base):
     __tablename__ = "platforms"
 
-    id: Mapped[Optional[int]] = mapped_column(
-        sqlalchemy.Integer, primary_key=True
-    )
+    id: Mapped[int] = mapped_column(sqlalchemy.Integer, primary_key=True)
     contact_mail: Mapped[Optional[str]] = mapped_column(
         sqlalchemy.Text, nullable=True
     )
@@ -318,7 +316,7 @@ class Repository(CustomRepoRepr, PermissionsMixin):
     production: Mapped[Optional[bool]] = mapped_column(
         sqlalchemy.Boolean, default=False, nullable=True
     )
-    pulp_href: Mapped[str] = mapped_column(sqlalchemy.Text)
+    pulp_href: Mapped[Optional[str]] = mapped_column(sqlalchemy.Text)
     export_path: Mapped[Optional[str]] = mapped_column(
         sqlalchemy.Text, nullable=True
     )
@@ -344,9 +342,7 @@ class RepositoryRemote(CustomRepoRepr):
         ),
     ]
 
-    id: Mapped[Optional[int]] = mapped_column(
-        sqlalchemy.Integer, primary_key=True
-    )
+    id: Mapped[int] = mapped_column(sqlalchemy.Integer, primary_key=True)
     name: Mapped[str] = mapped_column(sqlalchemy.Text, nullable=False)
     arch: Mapped[str] = mapped_column(sqlalchemy.Text, nullable=False)
     url: Mapped[str] = mapped_column(sqlalchemy.Text, nullable=False)
@@ -391,9 +387,7 @@ BuildDependency = sqlalchemy.Table(
 class Build(PermissionsMixin, TeamMixin, Base):
     __tablename__ = "builds"
 
-    id: Mapped[Optional[int]] = mapped_column(
-        sqlalchemy.Integer, primary_key=True
-    )
+    id: Mapped[int] = mapped_column(sqlalchemy.Integer, primary_key=True)
     created_at: Mapped[date_time] = mapped_column(
         sqlalchemy.DateTime,
         nullable=False,
@@ -476,9 +470,7 @@ BuildTaskDependency = sqlalchemy.Table(
 class BuildTask(TimeMixin, Base):
     __tablename__ = "build_tasks"
 
-    id: Mapped[Optional[int]] = mapped_column(
-        sqlalchemy.Integer, primary_key=True
-    )
+    id: Mapped[int] = mapped_column(sqlalchemy.Integer, primary_key=True)
     ts: Mapped[Optional[date_time]] = mapped_column(
         sqlalchemy.DateTime,
         nullable=True,
@@ -535,7 +527,7 @@ class BuildTask(TimeMixin, Base):
     )
     platform: Mapped["Platform"] = relationship("Platform")
     build: Mapped["Build"] = relationship("Build", back_populates="tasks")
-    dependencies: Mapped["BuildTask"] = relationship(
+    dependencies: Mapped[List["BuildTask"]] = relationship(
         "BuildTask",
         secondary=BuildTaskDependency,
         primaryjoin=(BuildTaskDependency.c.build_task_id == id),
@@ -560,12 +552,10 @@ class BuildTask(TimeMixin, Base):
 class BuildTaskRef(Base):
     __tablename__ = "build_task_refs"
 
-    id: Mapped[Optional[int]] = mapped_column(
-        sqlalchemy.Integer, primary_key=True
-    )
+    id: Mapped[int] = mapped_column(sqlalchemy.Integer, primary_key=True)
     url: Mapped[str] = mapped_column(sqlalchemy.TEXT, nullable=False)
-    git_ref: Mapped[str] = mapped_column(sqlalchemy.TEXT)
-    ref_type: Mapped[int] = mapped_column(sqlalchemy.Integer)
+    git_ref: Mapped[Optional[str]] = mapped_column(sqlalchemy.TEXT)
+    ref_type: Mapped[Optional[int]] = mapped_column(sqlalchemy.Integer)
     git_commit_hash: Mapped[Optional[str]] = mapped_column(
         sqlalchemy.TEXT, nullable=True
     )
@@ -599,9 +589,7 @@ class RpmModule(Base):
 class BuildTaskArtifact(Base):
     __tablename__ = "build_artifacts"
 
-    id: Mapped[Optional[int]] = mapped_column(
-        sqlalchemy.Integer, primary_key=True
-    )
+    id: Mapped[int] = mapped_column(sqlalchemy.Integer, primary_key=True)
     build_task_id: Mapped[int] = mapped_column(
         sqlalchemy.Integer,
         sqlalchemy.ForeignKey("build_tasks.id"),
@@ -645,9 +633,7 @@ class BuildTaskArtifact(Base):
 class SourceRpm(Base):
     __tablename__ = "source_rpms"
 
-    id: Mapped[Optional[int]] = mapped_column(
-        sqlalchemy.Integer, primary_key=True
-    )
+    id: Mapped[int] = mapped_column(sqlalchemy.Integer, primary_key=True)
     build_id: Mapped[int] = mapped_column(
         sqlalchemy.Integer,
         sqlalchemy.ForeignKey("builds.id"),
@@ -671,9 +657,7 @@ class SourceRpm(Base):
 class BinaryRpm(Base):
     __tablename__ = "binary_rpms"
 
-    id: Mapped[Optional[int]] = mapped_column(
-        sqlalchemy.Integer, primary_key=True
-    )
+    id: Mapped[int] = mapped_column(sqlalchemy.Integer, primary_key=True)
     build_id: Mapped[int] = mapped_column(
         sqlalchemy.Integer, sqlalchemy.ForeignKey("builds.id"), nullable=False
     )
@@ -841,9 +825,7 @@ TeamUserMapping = sqlalchemy.Table(
 class UserOauthAccount(SQLAlchemyBaseOAuthAccountTable[int], Base):
     __tablename__ = "user_oauth_accounts"
 
-    id: Mapped[Optional[int]] = mapped_column(
-        sqlalchemy.Integer, primary_key=True
-    )
+    id: Mapped[int] = mapped_column(sqlalchemy.Integer, primary_key=True)
     # Override SQLAlchemyBaseOAuthAccountTable access_token column length
     access_token: Mapped[str] = mapped_column(
         sqlalchemy.VARCHAR(length=2048),
@@ -862,7 +844,7 @@ class UserOauthAccount(SQLAlchemyBaseOAuthAccountTable[int], Base):
 class UserAccessToken(SQLAlchemyBaseAccessTokenTable[int], Base):
     __tablename__ = "user_access_tokens"
 
-    id: Mapped[Optional[int]] = mapped_column(
+    id: Mapped[int] = mapped_column(
         sqlalchemy.Integer, primary_key=True, autoincrement=True
     )
 
@@ -878,9 +860,7 @@ class UserAccessToken(SQLAlchemyBaseAccessTokenTable[int], Base):
 class User(SQLAlchemyBaseUserTable[int], Base):
     __tablename__ = "users"
 
-    id: Mapped[Optional[int]] = mapped_column(
-        sqlalchemy.Integer, primary_key=True
-    )
+    id: Mapped[int] = mapped_column(sqlalchemy.Integer, primary_key=True)
     username: Mapped[Optional[str]] = mapped_column(
         sqlalchemy.TEXT, nullable=True
     )
@@ -915,9 +895,7 @@ class User(SQLAlchemyBaseUserTable[int], Base):
 class Team(PermissionsMixin, Base):
     __tablename__ = "teams"
 
-    id: Mapped[Optional[int]] = mapped_column(
-        sqlalchemy.Integer, primary_key=True
-    )
+    id: Mapped[int] = mapped_column(sqlalchemy.Integer, primary_key=True)
     name: Mapped[str] = mapped_column(
         sqlalchemy.Text, nullable=False, unique=True
     )
@@ -1007,9 +985,7 @@ ProductPlatforms = sqlalchemy.Table(
 class Product(PermissionsMixin, TeamMixin, Base):
     __tablename__ = "products"
 
-    id: Mapped[Optional[int]] = mapped_column(
-        sqlalchemy.Integer, primary_key=True
-    )
+    id: Mapped[int] = mapped_column(sqlalchemy.Integer, primary_key=True)
     name: Mapped[str] = mapped_column(
         sqlalchemy.Text, nullable=False, unique=True
     )
@@ -1059,9 +1035,7 @@ class Product(PermissionsMixin, TeamMixin, Base):
 class TestTask(TimeMixin, Base):
     __tablename__ = "test_tasks"
 
-    id: Mapped[Optional[int]] = mapped_column(
-        sqlalchemy.Integer, primary_key=True
-    )
+    id: Mapped[int] = mapped_column(sqlalchemy.Integer, primary_key=True)
     package_name: Mapped[str] = mapped_column(sqlalchemy.TEXT, nullable=False)
     package_version: Mapped[str] = mapped_column(
         sqlalchemy.TEXT, nullable=False
@@ -1112,9 +1086,7 @@ class TestTask(TimeMixin, Base):
 
 class TestTaskArtifact(Base):
     __tablename__ = "test_task_artifacts"
-    id: Mapped[Optional[int]] = mapped_column(
-        sqlalchemy.Integer, primary_key=True
-    )
+    id: Mapped[int] = mapped_column(sqlalchemy.Integer, primary_key=True)
     test_task_id: Mapped[int] = mapped_column(
         sqlalchemy.Integer,
         sqlalchemy.ForeignKey("test_tasks.id"),
@@ -1156,9 +1128,7 @@ class PackageTestRepository(Base):
 
 class TestRepository(Base):
     __tablename__ = "test_repositories"
-    id: Mapped[Optional[int]] = mapped_column(
-        sqlalchemy.Integer, primary_key=True
-    )
+    id: Mapped[int] = mapped_column(sqlalchemy.Integer, primary_key=True)
     name: Mapped[str] = mapped_column(
         sqlalchemy.Text, nullable=False, unique=True
     )
@@ -1179,9 +1149,7 @@ class TestRepository(Base):
 class Release(PermissionsMixin, TeamMixin, TimeMixin, Base):
     __tablename__ = "build_releases"
 
-    id: Mapped[Optional[int]] = mapped_column(
-        sqlalchemy.Integer, primary_key=True
-    )
+    id: Mapped[int] = mapped_column(sqlalchemy.Integer, primary_key=True)
     build_ids: Mapped[List[int]] = mapped_column(
         sqlalchemy.ARRAY(sqlalchemy.Integer, dimensions=1), nullable=False
     )
@@ -1253,9 +1221,7 @@ SignKeyRoleMapping = sqlalchemy.Table(
 class SignKey(PermissionsMixin, Base):
     __tablename__ = "sign_keys"
 
-    id: Mapped[Optional[int]] = mapped_column(
-        sqlalchemy.Integer, primary_key=True
-    )
+    id: Mapped[int] = mapped_column(sqlalchemy.Integer, primary_key=True)
     name: Mapped[str] = mapped_column(sqlalchemy.Text)
     # FIXME: change nullable to False after population
     is_community: Mapped[Optional[bool]] = mapped_column(
@@ -1308,9 +1274,7 @@ class SignKey(PermissionsMixin, Base):
 class GenKeyTask(Base):
     __tablename__ = "gen_key_tasks"
 
-    id: Mapped[Optional[int]] = mapped_column(
-        sqlalchemy.Integer, primary_key=True
-    )
+    id: Mapped[int] = mapped_column(sqlalchemy.Integer, primary_key=True)
     status: Mapped[int] = mapped_column(
         sqlalchemy.Integer, default=GenKeyStatus.IDLE
     )
@@ -1328,9 +1292,7 @@ class GenKeyTask(Base):
 class SignTask(TimeMixin, Base):
     __tablename__ = "sign_tasks"
 
-    id: Mapped[Optional[int]] = mapped_column(
-        sqlalchemy.Integer, primary_key=True
-    )
+    id: Mapped[int] = mapped_column(sqlalchemy.Integer, primary_key=True)
     build_id: Mapped[int] = mapped_column(
         sqlalchemy.Integer, sqlalchemy.ForeignKey("builds.id"), nullable=False
     )
@@ -1361,9 +1323,7 @@ class SignTask(TimeMixin, Base):
 class ExportTask(Base):
     __tablename__ = "export_tasks"
 
-    id: Mapped[Optional[int]] = mapped_column(
-        sqlalchemy.Integer, primary_key=True
-    )
+    id: Mapped[int] = mapped_column(sqlalchemy.Integer, primary_key=True)
     name: Mapped[str] = mapped_column(sqlalchemy.Text, nullable=False)
     status: Mapped[int] = mapped_column(sqlalchemy.Integer, nullable=False)
     exported_at: Mapped[Optional[date_time]] = mapped_column(
@@ -1374,9 +1334,7 @@ class ExportTask(Base):
 class RepoExporter(Base):
     __tablename__ = "repo_exporters"
 
-    id: Mapped[Optional[int]] = mapped_column(
-        sqlalchemy.Integer, primary_key=True
-    )
+    id: Mapped[int] = mapped_column(sqlalchemy.Integer, primary_key=True)
     path: Mapped[str] = mapped_column(sqlalchemy.Text, nullable=False)
     exported_id: Mapped[int] = mapped_column(
         sqlalchemy.Integer,
@@ -1397,9 +1355,7 @@ class RepoExporter(Base):
 class PlatformFlavour(PermissionsMixin, Base):
     __tablename__ = "platform_flavours"
 
-    id: Mapped[Optional[int]] = mapped_column(
-        sqlalchemy.Integer, primary_key=True
-    )
+    id: Mapped[int] = mapped_column(sqlalchemy.Integer, primary_key=True)
     name: Mapped[str] = mapped_column(
         sqlalchemy.Text, nullable=False, unique=True
     )
@@ -1416,10 +1372,8 @@ class PlatformFlavour(PermissionsMixin, Base):
 
 class NewErrataRecord(Base):
     __tablename__ = "new_errata_records"
-    id: Mapped[Optional[str]] = mapped_column(
-        sqlalchemy.Text, primary_key=True
-    )
-    platform_id: Mapped[Optional[int]] = mapped_column(
+    id: Mapped[str] = mapped_column(sqlalchemy.Text, primary_key=True)
+    platform_id: Mapped[int] = mapped_column(
         sqlalchemy.Integer,
         sqlalchemy.ForeignKey(
             "platforms.id",
@@ -1654,9 +1608,7 @@ class NewErrataToALBSPackage(Base):
         ),
     )
 
-    id: Mapped[Optional[int]] = mapped_column(
-        sqlalchemy.Integer, primary_key=True
-    )
+    id: Mapped[int] = mapped_column(sqlalchemy.Integer, primary_key=True)
     errata_package_id: Mapped[int] = mapped_column(
         sqlalchemy.Integer,
         sqlalchemy.ForeignKey(
@@ -1724,9 +1676,7 @@ class NewErrataToALBSPackage(Base):
 class ErrataRecord(Base):
     __tablename__ = "errata_records"
 
-    id: Mapped[Optional[str]] = mapped_column(
-        sqlalchemy.Text, primary_key=True
-    )
+    id: Mapped[str] = mapped_column(sqlalchemy.Text, primary_key=True)
     platform_id: Mapped[int] = mapped_column(
         sqlalchemy.Integer,
         sqlalchemy.ForeignKey("platforms.id"),
@@ -1867,9 +1817,7 @@ class ErrataRecord(Base):
 class ErrataReference(Base):
     __tablename__ = "errata_references"
 
-    id: Mapped[Optional[int]] = mapped_column(
-        sqlalchemy.Integer, primary_key=True
-    )
+    id: Mapped[int] = mapped_column(sqlalchemy.Integer, primary_key=True)
     href: Mapped[str] = mapped_column(sqlalchemy.Text, nullable=False)
     ref_id: Mapped[str] = mapped_column(sqlalchemy.Text, nullable=False)
     title: Mapped[str] = mapped_column(sqlalchemy.Text, nullable=False)
@@ -1906,9 +1854,7 @@ class ErrataReference(Base):
 class ErrataCVE(Base):
     __tablename__ = "errata_cves"
 
-    id: Mapped[Optional[str]] = mapped_column(
-        sqlalchemy.Text, primary_key=True
-    )
+    id: Mapped[str] = mapped_column(sqlalchemy.Text, primary_key=True)
     cvss3: Mapped[str] = mapped_column(sqlalchemy.Text, nullable=False)
     cwe: Mapped[Optional[str]] = mapped_column(sqlalchemy.Text, nullable=True)
     impact: Mapped[Optional[str]] = mapped_column(
@@ -1920,9 +1866,7 @@ class ErrataCVE(Base):
 class ErrataPackage(Base):
     __tablename__ = "errata_packages"
 
-    id: Mapped[Optional[int]] = mapped_column(
-        sqlalchemy.Integer, primary_key=True
-    )
+    id: Mapped[int] = mapped_column(sqlalchemy.Integer, primary_key=True)
     errata_record_id: Mapped[str] = mapped_column(
         sqlalchemy.Text,
         sqlalchemy.ForeignKey(
@@ -1960,9 +1904,7 @@ class ErrataToALBSPackage(Base):
         ),
     )
 
-    id: Mapped[Optional[int]] = mapped_column(
-        sqlalchemy.Integer, primary_key=True
-    )
+    id: Mapped[int] = mapped_column(sqlalchemy.Integer, primary_key=True)
     errata_package_id: Mapped[int] = mapped_column(
         sqlalchemy.Integer,
         sqlalchemy.ForeignKey(
@@ -2029,9 +1971,7 @@ class ErrataToALBSPackage(Base):
 class PerformanceStats(Base):
     __tablename__ = "performance_stats"
 
-    id: Mapped[Optional[int]] = mapped_column(
-        sqlalchemy.Integer, primary_key=True
-    )
+    id: Mapped[int] = mapped_column(sqlalchemy.Integer, primary_key=True)
     statistics: Mapped[Optional[Dict[str, Any]]] = mapped_column(
         JSONB,
         nullable=True,

--- a/alws/models.py
+++ b/alws/models.py
@@ -1,7 +1,6 @@
 import asyncio
 import datetime
 import re
-from datetime import datetime as date_time
 from typing import Any, Dict, List, Literal, Optional
 
 import sqlalchemy
@@ -127,11 +126,11 @@ class PermissionsMixin:
 @declarative_mixin
 class TimeMixin:
     @declared_attr
-    def started_at(cls) -> Mapped[Optional[date_time]]:
+    def started_at(cls) -> Mapped[Optional[datetime.datetime]]:
         return mapped_column(sqlalchemy.DateTime, nullable=True)
 
     @declared_attr
-    def finished_at(cls) -> Mapped[Optional[date_time]]:
+    def finished_at(cls) -> Mapped[Optional[datetime.datetime]]:
         return mapped_column(sqlalchemy.DateTime, nullable=True)
 
 
@@ -388,12 +387,12 @@ class Build(PermissionsMixin, TeamMixin, Base):
     __tablename__ = "builds"
 
     id: Mapped[int] = mapped_column(sqlalchemy.Integer, primary_key=True)
-    created_at: Mapped[date_time] = mapped_column(
+    created_at: Mapped[datetime.datetime] = mapped_column(
         sqlalchemy.DateTime,
         nullable=False,
         default=func.current_timestamp(),
     )
-    finished_at: Mapped[Optional[date_time]] = mapped_column(
+    finished_at: Mapped[Optional[datetime.datetime]] = mapped_column(
         sqlalchemy.DateTime, nullable=True
     )
     tasks: Mapped[List["BuildTask"]] = relationship(
@@ -471,7 +470,7 @@ class BuildTask(TimeMixin, Base):
     __tablename__ = "build_tasks"
 
     id: Mapped[int] = mapped_column(sqlalchemy.Integer, primary_key=True)
-    ts: Mapped[Optional[date_time]] = mapped_column(
+    ts: Mapped[Optional[datetime.datetime]] = mapped_column(
         sqlalchemy.DateTime,
         nullable=True,
         index=True,
@@ -1075,7 +1074,7 @@ class TestTask(TimeMixin, Base):
         nullable=True,
     )
     repository: Mapped["Repository"] = relationship("Repository")
-    scheduled_at: Mapped[Optional[date_time]] = mapped_column(
+    scheduled_at: Mapped[Optional[datetime.datetime]] = mapped_column(
         sqlalchemy.DateTime, nullable=True
     )
     performance_stats: Mapped["PerformanceStats"] = relationship(
@@ -1153,7 +1152,7 @@ class Release(PermissionsMixin, TeamMixin, TimeMixin, Base):
     build_ids: Mapped[List[int]] = mapped_column(
         sqlalchemy.ARRAY(sqlalchemy.Integer, dimensions=1), nullable=False
     )
-    created_at: Mapped[Optional[date_time]] = mapped_column(
+    created_at: Mapped[Optional[datetime.datetime]] = mapped_column(
         sqlalchemy.DateTime,
         nullable=True,
         default=func.current_timestamp(),
@@ -1237,7 +1236,7 @@ class SignKey(PermissionsMixin, Base):
         sqlalchemy.String(40), unique=True
     )
     public_url: Mapped[str] = mapped_column(sqlalchemy.Text)
-    inserted: Mapped[date_time] = mapped_column(
+    inserted: Mapped[datetime.datetime] = mapped_column(
         sqlalchemy.DateTime, default=datetime.datetime.utcnow()
     )
     product_id: Mapped[Optional[int]] = mapped_column(
@@ -1306,7 +1305,7 @@ class SignTask(TimeMixin, Base):
     status: Mapped[int] = mapped_column(
         sqlalchemy.Integer, default=SignStatus.IDLE
     )
-    ts: Mapped[Optional[date_time]] = mapped_column(
+    ts: Mapped[Optional[datetime.datetime]] = mapped_column(
         sqlalchemy.DateTime, nullable=True
     )
     error_message: Mapped[Optional[str]] = mapped_column(
@@ -1326,7 +1325,7 @@ class ExportTask(Base):
     id: Mapped[int] = mapped_column(sqlalchemy.Integer, primary_key=True)
     name: Mapped[str] = mapped_column(sqlalchemy.Text, nullable=False)
     status: Mapped[int] = mapped_column(sqlalchemy.Integer, nullable=False)
-    exported_at: Mapped[Optional[date_time]] = mapped_column(
+    exported_at: Mapped[Optional[datetime.datetime]] = mapped_column(
         sqlalchemy.DateTime, nullable=True
     )
 
@@ -1413,10 +1412,10 @@ class NewErrataRecord(Base):
         sqlalchemy.Boolean, nullable=True
     )
 
-    issued_date: Mapped[date_time] = mapped_column(
+    issued_date: Mapped[datetime.datetime] = mapped_column(
         sqlalchemy.DateTime, nullable=False
     )
-    updated_date: Mapped[date_time] = mapped_column(
+    updated_date: Mapped[datetime.datetime] = mapped_column(
         sqlalchemy.DateTime, nullable=False
     )
     description: Mapped[Optional[str]] = mapped_column(
@@ -1713,10 +1712,10 @@ class ErrataRecord(Base):
         sqlalchemy.Boolean, nullable=True
     )
 
-    issued_date: Mapped[date_time] = mapped_column(
+    issued_date: Mapped[datetime.datetime] = mapped_column(
         sqlalchemy.DateTime, nullable=False
     )
-    updated_date: Mapped[date_time] = mapped_column(
+    updated_date: Mapped[datetime.datetime] = mapped_column(
         sqlalchemy.DateTime, nullable=False
     )
     description: Mapped[Optional[str]] = mapped_column(

--- a/alws/models.py
+++ b/alws/models.py
@@ -258,6 +258,11 @@ class Platform(PermissionsMixin, Base):
 class CustomRepoRepr(Base):
     __abstract__ = True
 
+    def __init__(self):
+        self.url = None
+        self.arch = None
+        self.name = None
+
     def __repr__(self):
         return f"{self.__class__.__name__}: {self.name} {self.arch} {self.url}"
 
@@ -1319,7 +1324,7 @@ class NewErrataPackage(Base):
     platform_id = sqlalchemy.Column(sqlalchemy.Integer)
     platform_specific_errata_record = relationship(
         "NewErrataRecord",
-        foreign_keys=[errata_record_id, platform_id],
+        foreign_keys=str([errata_record_id, platform_id]),
         cascade="all, delete",
         primaryjoin="and_(NewErrataPackage.errata_record_id == NewErrataRecord.id,"
         "NewErrataPackage.platform_id == NewErrataRecord.platform_id)",
@@ -1360,7 +1365,7 @@ class NewErrataReference(Base):
     platform_id = sqlalchemy.Column(sqlalchemy.Integer)
     platform_specific_errata_record = relationship(
         "NewErrataRecord",
-        foreign_keys=[errata_record_id, platform_id],
+        foreign_keys=str([errata_record_id, platform_id]),
         cascade="all, delete",
         primaryjoin="and_(NewErrataReference.errata_record_id == NewErrataRecord.id,"
         "NewErrataReference.platform_id == NewErrataRecord.platform_id)",

--- a/alws/models.py
+++ b/alws/models.py
@@ -536,7 +536,7 @@ class BuildTask(TimeMixin, Base):
         "TestTask", back_populates="build_task", order_by="TestTask.revision"
     )
     rpm_module: Mapped["RpmModule"] = relationship("RpmModule")
-    performance_stats: Mapped["PerformanceStats"] = relationship(
+    performance_stats: Mapped[List["PerformanceStats"]] = relationship(
         "PerformanceStats",
         back_populates="build_task",
     )
@@ -1077,7 +1077,7 @@ class TestTask(TimeMixin, Base):
     scheduled_at: Mapped[Optional[datetime.datetime]] = mapped_column(
         sqlalchemy.DateTime, nullable=True
     )
-    performance_stats: Mapped["PerformanceStats"] = relationship(
+    performance_stats: Mapped[List["PerformanceStats"]] = relationship(
         "PerformanceStats",
         back_populates="test_task",
     )

--- a/alws/models.py
+++ b/alws/models.py
@@ -13,7 +13,12 @@ from fastapi_users_db_sqlalchemy.access_token import (
 )
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.associationproxy import association_proxy
-from sqlalchemy.orm import declarative_mixin, declared_attr, relationship
+from sqlalchemy.orm import (
+    declarative_mixin,
+    declared_attr,
+    mapped_column,
+    relationship,
+)
 from sqlalchemy.sql import func
 
 from alws.constants import (
@@ -51,7 +56,7 @@ class TeamMixin:
     @declared_attr
     def team_id(cls):
         # FIXME: Change nullable to False after owner population
-        return sqlalchemy.Column(
+        return mapped_column(
             sqlalchemy.Integer,
             sqlalchemy.ForeignKey(
                 "teams.id",
@@ -70,7 +75,7 @@ class PermissionsMixin:
     @declared_attr
     def owner_id(cls):
         # FIXME: Change nullable to False after owner population
-        return sqlalchemy.Column(
+        return mapped_column(
             sqlalchemy.Integer,
             sqlalchemy.ForeignKey(
                 "users.id",
@@ -83,7 +88,7 @@ class PermissionsMixin:
     def owner(cls):
         return relationship("User")
 
-    permissions = sqlalchemy.Column(
+    permissions = mapped_column(
         sqlalchemy.Integer, nullable=False, default=764
     )
 
@@ -121,11 +126,11 @@ class PermissionsMixin:
 class TimeMixin:
     @declared_attr
     def started_at(cls):
-        return sqlalchemy.Column(sqlalchemy.DateTime, nullable=True)
+        return mapped_column(sqlalchemy.DateTime, nullable=True)
 
     @declared_attr
     def finished_at(cls):
-        return sqlalchemy.Column(sqlalchemy.DateTime, nullable=True)
+        return mapped_column(sqlalchemy.DateTime, nullable=True)
 
 
 PlatformRepo = sqlalchemy.Table(
@@ -224,24 +229,24 @@ PlatformRoleMapping = sqlalchemy.Table(
 class Platform(PermissionsMixin, Base):
     __tablename__ = "platforms"
 
-    id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
-    contact_mail = sqlalchemy.Column(sqlalchemy.Text, nullable=True)
-    copyright = sqlalchemy.Column(sqlalchemy.Text, nullable=True)
-    type = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    distr_type = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    distr_version = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    module_build_index = sqlalchemy.Column(sqlalchemy.Integer, default=1)
-    modularity = sqlalchemy.Column(JSONB, nullable=True)
-    test_dist_name = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    name = sqlalchemy.Column(
+    id = mapped_column(sqlalchemy.Integer, primary_key=True)
+    contact_mail = mapped_column(sqlalchemy.Text, nullable=True)
+    copyright = mapped_column(sqlalchemy.Text, nullable=True)
+    type = mapped_column(sqlalchemy.Text, nullable=False)
+    distr_type = mapped_column(sqlalchemy.Text, nullable=False)
+    distr_version = mapped_column(sqlalchemy.Text, nullable=False)
+    module_build_index = mapped_column(sqlalchemy.Integer, default=1)
+    modularity = mapped_column(JSONB, nullable=True)
+    test_dist_name = mapped_column(sqlalchemy.Text, nullable=False)
+    name = mapped_column(
         sqlalchemy.Text, nullable=False, unique=True, index=True
     )
-    priority = sqlalchemy.Column(sqlalchemy.Integer, nullable=True)
-    arch_list = sqlalchemy.Column(JSONB, nullable=False)
-    copy_priority_arches = sqlalchemy.Column(JSONB, nullable=True)
-    weak_arch_list = sqlalchemy.Column(JSONB, nullable=True)
-    data = sqlalchemy.Column(JSONB, nullable=False)
-    is_reference = sqlalchemy.Column(
+    priority = mapped_column(sqlalchemy.Integer, nullable=True)
+    arch_list = mapped_column(JSONB, nullable=False)
+    copy_priority_arches = mapped_column(JSONB, nullable=True)
+    weak_arch_list = mapped_column(JSONB, nullable=True)
+    data = mapped_column(JSONB, nullable=False)
+    is_reference = mapped_column(
         sqlalchemy.Boolean, default=False, nullable=True
     )
     reference_platforms = relationship(
@@ -257,11 +262,6 @@ class Platform(PermissionsMixin, Base):
 
 class CustomRepoRepr(Base):
     __abstract__ = True
-
-    def __init__(self):
-        self.url = None
-        self.arch = None
-        self.name = None
 
     def __repr__(self):
         return f"{self.__class__.__name__}: {self.name} {self.arch} {self.url}"
@@ -279,26 +279,24 @@ class Repository(CustomRepoRepr, PermissionsMixin):
         ),
     )
 
-    id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
-    name = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    arch = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    url = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    type = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    debug = sqlalchemy.Column(sqlalchemy.Boolean, default=False)
-    mock_enabled = sqlalchemy.Column(
+    id = mapped_column(sqlalchemy.Integer, primary_key=True)
+    name = mapped_column(sqlalchemy.Text, nullable=False)
+    arch = mapped_column(sqlalchemy.Text, nullable=False)
+    url = mapped_column(sqlalchemy.Text, nullable=False)
+    type = mapped_column(sqlalchemy.Text, nullable=False)
+    debug = mapped_column(sqlalchemy.Boolean, default=False)
+    mock_enabled = mapped_column(
         sqlalchemy.Boolean,
         default=True,
         nullable=True,
     )
-    production = sqlalchemy.Column(
+    production = mapped_column(
         sqlalchemy.Boolean, default=False, nullable=True
     )
-    pulp_href = sqlalchemy.Column(sqlalchemy.Text)
-    export_path = sqlalchemy.Column(sqlalchemy.Text, nullable=True)
-    priority = sqlalchemy.Column(
-        sqlalchemy.Integer, default=10, nullable=False
-    )
-    platform_id = sqlalchemy.Column(
+    pulp_href = mapped_column(sqlalchemy.Text)
+    export_path = mapped_column(sqlalchemy.Text, nullable=True)
+    priority = mapped_column(sqlalchemy.Integer, default=10, nullable=False)
+    platform_id = mapped_column(
         sqlalchemy.Integer,
         sqlalchemy.ForeignKey("platforms.id"),
         nullable=True,
@@ -317,11 +315,11 @@ class RepositoryRemote(CustomRepoRepr):
         ),
     ]
 
-    id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
-    name = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    arch = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    url = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    pulp_href = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
+    id = mapped_column(sqlalchemy.Integer, primary_key=True)
+    name = mapped_column(sqlalchemy.Text, nullable=False)
+    arch = mapped_column(sqlalchemy.Text, nullable=False)
+    url = mapped_column(sqlalchemy.Text, nullable=False)
+    pulp_href = mapped_column(sqlalchemy.Text, nullable=False)
 
 
 BuildRepo = sqlalchemy.Table(
@@ -363,13 +361,13 @@ BuildDependency = sqlalchemy.Table(
 class Build(PermissionsMixin, TeamMixin, Base):
     __tablename__ = "builds"
 
-    id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
-    created_at = sqlalchemy.Column(
+    id = mapped_column(sqlalchemy.Integer, primary_key=True)
+    created_at = mapped_column(
         sqlalchemy.DateTime,
         nullable=False,
         default=func.current_timestamp(),
     )
-    finished_at = sqlalchemy.Column(sqlalchemy.DateTime, nullable=True)
+    finished_at = mapped_column(sqlalchemy.DateTime, nullable=True)
     tasks = relationship("BuildTask", back_populates="build")
     sign_tasks = relationship(
         "SignTask",
@@ -383,8 +381,8 @@ class Build(PermissionsMixin, TeamMixin, Base):
         primaryjoin=(BuildDependency.c.build_id == id),
         secondaryjoin=(BuildDependency.c.build_dependency == id),
     )
-    mock_options = sqlalchemy.Column(JSONB)
-    release_id = sqlalchemy.Column(
+    mock_options = mapped_column(JSONB)
+    release_id = mapped_column(
         sqlalchemy.Integer,
         sqlalchemy.ForeignKey(
             "build_releases.id",
@@ -406,11 +404,9 @@ class Build(PermissionsMixin, TeamMixin, Base):
         cascade="all, delete",
         passive_deletes=True,
     )
-    released = sqlalchemy.Column(sqlalchemy.Boolean, default=False)
-    signed = sqlalchemy.Column(
-        sqlalchemy.Boolean, default=False, nullable=True
-    )
-    cancel_testing = sqlalchemy.Column(
+    released = mapped_column(sqlalchemy.Boolean, default=False)
+    signed = mapped_column(sqlalchemy.Boolean, default=False, nullable=True)
+    cancel_testing = mapped_column(
         sqlalchemy.Boolean, default=False, nullable=False
     )
 
@@ -436,13 +432,13 @@ BuildTaskDependency = sqlalchemy.Table(
 class BuildTask(TimeMixin, Base):
     __tablename__ = "build_tasks"
 
-    id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
-    ts = sqlalchemy.Column(
+    id = mapped_column(sqlalchemy.Integer, primary_key=True)
+    ts = mapped_column(
         sqlalchemy.DateTime,
         nullable=True,
         index=True,
     )
-    build_id = sqlalchemy.Column(
+    build_id = mapped_column(
         sqlalchemy.Integer,
         sqlalchemy.ForeignKey("builds.id"),
         # saw https://stackoverflow.com/questions/
@@ -450,40 +446,40 @@ class BuildTask(TimeMixin, Base):
         nullable=False,
         index=True,
     )
-    platform_id = sqlalchemy.Column(
+    platform_id = mapped_column(
         sqlalchemy.Integer,
         sqlalchemy.ForeignKey("platforms.id"),
         nullable=False,
     )
-    ref_id = sqlalchemy.Column(
+    ref_id = mapped_column(
         sqlalchemy.Integer,
         sqlalchemy.ForeignKey("build_task_refs.id"),
         nullable=False,
         index=True,
     )
-    rpm_module_id = sqlalchemy.Column(
+    rpm_module_id = mapped_column(
         sqlalchemy.Integer,
         sqlalchemy.ForeignKey("rpm_module.id"),
         nullable=True,
     )
-    status = sqlalchemy.Column(
+    status = mapped_column(
         sqlalchemy.Integer,
         nullable=False,
         index=True,
     )
-    index = sqlalchemy.Column(sqlalchemy.Integer, nullable=False)
-    arch = sqlalchemy.Column(
+    index = mapped_column(sqlalchemy.Integer, nullable=False)
+    arch = mapped_column(
         sqlalchemy.VARCHAR(length=50),
         nullable=False,
         index=True,
     )
-    is_secure_boot = sqlalchemy.Column(
+    is_secure_boot = mapped_column(
         sqlalchemy.Boolean, default=False, nullable=True
     )
-    mock_options = sqlalchemy.Column(JSONB)
+    mock_options = mapped_column(JSONB)
     ref = relationship("BuildTaskRef")
-    alma_commit_cas_hash = sqlalchemy.Column(sqlalchemy.Text, nullable=True)
-    is_cas_authenticated = sqlalchemy.Column(
+    alma_commit_cas_hash = mapped_column(sqlalchemy.Text, nullable=True)
+    is_cas_authenticated = mapped_column(
         sqlalchemy.Boolean, default=False, nullable=True
     )
     artifacts = relationship("BuildTaskArtifact", back_populates="build_task")
@@ -503,32 +499,32 @@ class BuildTask(TimeMixin, Base):
         "PerformanceStats",
         back_populates="build_task",
     )
-    built_srpm_url = sqlalchemy.Column(sqlalchemy.VARCHAR, nullable=True)
-    error = sqlalchemy.Column(sqlalchemy.Text, nullable=True, default=None)
+    built_srpm_url = mapped_column(sqlalchemy.VARCHAR, nullable=True)
+    error = mapped_column(sqlalchemy.Text, nullable=True, default=None)
 
 
 class BuildTaskRef(Base):
     __tablename__ = "build_task_refs"
 
-    id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
-    url = sqlalchemy.Column(sqlalchemy.TEXT, nullable=False)
-    git_ref = sqlalchemy.Column(sqlalchemy.TEXT)
-    ref_type = sqlalchemy.Column(sqlalchemy.Integer)
-    git_commit_hash = sqlalchemy.Column(sqlalchemy.TEXT, nullable=True)
-    test_configuration = sqlalchemy.Column(JSONB, nullable=True)
+    id = mapped_column(sqlalchemy.Integer, primary_key=True)
+    url = mapped_column(sqlalchemy.TEXT, nullable=False)
+    git_ref = mapped_column(sqlalchemy.TEXT)
+    ref_type = mapped_column(sqlalchemy.Integer)
+    git_commit_hash = mapped_column(sqlalchemy.TEXT, nullable=True)
+    test_configuration = mapped_column(JSONB, nullable=True)
 
 
 class RpmModule(Base):
     __tablename__ = "rpm_module"
 
-    id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
-    name = sqlalchemy.Column(sqlalchemy.TEXT, nullable=False)
-    version = sqlalchemy.Column(sqlalchemy.TEXT, nullable=False)
-    stream = sqlalchemy.Column(sqlalchemy.TEXT, nullable=False)
-    context = sqlalchemy.Column(sqlalchemy.TEXT, nullable=False)
-    arch = sqlalchemy.Column(sqlalchemy.TEXT, nullable=False)
-    pulp_href = sqlalchemy.Column(sqlalchemy.TEXT, nullable=False)
-    sha256 = sqlalchemy.Column(sqlalchemy.VARCHAR(64), nullable=True)
+    id = mapped_column(sqlalchemy.Integer, primary_key=True)
+    name = mapped_column(sqlalchemy.TEXT, nullable=False)
+    version = mapped_column(sqlalchemy.TEXT, nullable=False)
+    stream = mapped_column(sqlalchemy.TEXT, nullable=False)
+    context = mapped_column(sqlalchemy.TEXT, nullable=False)
+    arch = mapped_column(sqlalchemy.TEXT, nullable=False)
+    pulp_href = mapped_column(sqlalchemy.TEXT, nullable=False)
+    sha256 = mapped_column(sqlalchemy.VARCHAR(64), nullable=True)
 
     @property
     def nvsca(self):
@@ -541,19 +537,19 @@ class RpmModule(Base):
 class BuildTaskArtifact(Base):
     __tablename__ = "build_artifacts"
 
-    id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
-    build_task_id = sqlalchemy.Column(
+    id = mapped_column(sqlalchemy.Integer, primary_key=True)
+    build_task_id = mapped_column(
         sqlalchemy.Integer,
         sqlalchemy.ForeignKey("build_tasks.id"),
         nullable=False,
         index=True,
     )
-    name = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    type = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    href = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
+    name = mapped_column(sqlalchemy.Text, nullable=False)
+    type = mapped_column(sqlalchemy.Text, nullable=False)
+    href = mapped_column(sqlalchemy.Text, nullable=False)
     build_task = relationship("BuildTask", back_populates="artifacts")
-    cas_hash = sqlalchemy.Column(sqlalchemy.Text, nullable=True)
-    sign_key_id = sqlalchemy.Column(
+    cas_hash = mapped_column(sqlalchemy.Text, nullable=True)
+    sign_key_id = mapped_column(
         sqlalchemy.Integer,
         sqlalchemy.ForeignKey(
             "sign_keys.id",
@@ -579,15 +575,15 @@ class BuildTaskArtifact(Base):
 class SourceRpm(Base):
     __tablename__ = "source_rpms"
 
-    id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
-    build_id = sqlalchemy.Column(
+    id = mapped_column(sqlalchemy.Integer, primary_key=True)
+    build_id = mapped_column(
         sqlalchemy.Integer,
         sqlalchemy.ForeignKey("builds.id"),
         nullable=False,
         index=True,
     )
     build = relationship("Build", back_populates="source_rpms")
-    artifact_id = sqlalchemy.Column(
+    artifact_id = mapped_column(
         sqlalchemy.Integer,
         sqlalchemy.ForeignKey("build_artifacts.id"),
         nullable=False,
@@ -599,18 +595,18 @@ class SourceRpm(Base):
 class BinaryRpm(Base):
     __tablename__ = "binary_rpms"
 
-    id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
-    build_id = sqlalchemy.Column(
+    id = mapped_column(sqlalchemy.Integer, primary_key=True)
+    build_id = mapped_column(
         sqlalchemy.Integer, sqlalchemy.ForeignKey("builds.id"), nullable=False
     )
     build = relationship("Build", back_populates="binary_rpms")
-    artifact_id = sqlalchemy.Column(
+    artifact_id = mapped_column(
         sqlalchemy.Integer,
         sqlalchemy.ForeignKey("build_artifacts.id"),
         nullable=False,
     )
     artifact = relationship("BuildTaskArtifact")
-    source_rpm_id = sqlalchemy.Column(
+    source_rpm_id = mapped_column(
         sqlalchemy.Integer,
         sqlalchemy.ForeignKey("source_rpms.id"),
         nullable=False,
@@ -621,9 +617,9 @@ class BinaryRpm(Base):
 class UserAction(Base):
     __tablename__ = "user_actions"
 
-    id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
-    name = sqlalchemy.Column(sqlalchemy.String(100), unique=True)
-    description = sqlalchemy.Column(sqlalchemy.TEXT, nullable=True)
+    id = mapped_column(sqlalchemy.Integer, primary_key=True)
+    name = mapped_column(sqlalchemy.String(100), unique=True)
+    description = mapped_column(sqlalchemy.TEXT, nullable=True)
 
 
 ActionRoleMapping = sqlalchemy.Table(
@@ -655,8 +651,8 @@ ActionRoleMapping = sqlalchemy.Table(
 class UserRole(Base):
     __tablename__ = "user_roles"
 
-    id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
-    name = sqlalchemy.Column(sqlalchemy.String(100), unique=True)
+    id = mapped_column(sqlalchemy.Integer, primary_key=True)
+    name = mapped_column(sqlalchemy.String(100), unique=True)
     actions = relationship("UserAction", secondary=ActionRoleMapping)
 
     def __repr__(self):
@@ -759,16 +755,16 @@ TeamUserMapping = sqlalchemy.Table(
 class UserOauthAccount(SQLAlchemyBaseOAuthAccountTable[int], Base):
     __tablename__ = "user_oauth_accounts"
 
-    id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
+    id = mapped_column(sqlalchemy.Integer, primary_key=True)
     # Override SQLAlchemyBaseOAuthAccountTable access_token column length
-    access_token = sqlalchemy.Column(
+    access_token = mapped_column(
         sqlalchemy.VARCHAR(length=2048),
         nullable=False,
     )
 
     @declared_attr
     def user_id(cls):
-        return sqlalchemy.Column(
+        return mapped_column(
             sqlalchemy.Integer,
             sqlalchemy.ForeignKey("users.id", ondelete="cascade"),
             nullable=False,
@@ -778,13 +774,13 @@ class UserOauthAccount(SQLAlchemyBaseOAuthAccountTable[int], Base):
 class UserAccessToken(SQLAlchemyBaseAccessTokenTable[int], Base):
     __tablename__ = "user_access_tokens"
 
-    id = sqlalchemy.Column(
+    id = mapped_column(
         sqlalchemy.Integer, primary_key=True, autoincrement=True
     )
 
     @declared_attr
     def user_id(cls):
-        return sqlalchemy.Column(
+        return mapped_column(
             sqlalchemy.Integer,
             sqlalchemy.ForeignKey("users.id", ondelete="cascade"),
             nullable=False,
@@ -794,18 +790,18 @@ class UserAccessToken(SQLAlchemyBaseAccessTokenTable[int], Base):
 class User(SQLAlchemyBaseUserTable[int], Base):
     __tablename__ = "users"
 
-    id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
-    username = sqlalchemy.Column(sqlalchemy.TEXT, nullable=True)
-    first_name = sqlalchemy.Column(sqlalchemy.String(320), nullable=True)
-    last_name = sqlalchemy.Column(sqlalchemy.String(320), nullable=True)
+    id = mapped_column(sqlalchemy.Integer, primary_key=True)
+    username = mapped_column(sqlalchemy.TEXT, nullable=True)
+    first_name = mapped_column(sqlalchemy.String(320), nullable=True)
+    last_name = mapped_column(sqlalchemy.String(320), nullable=True)
     # Override SQLAlchemyBaseUserTable email attribute to keep current type
-    email = sqlalchemy.Column(
+    email = mapped_column(
         sqlalchemy.TEXT,
         unique=True,
         index=True,
         nullable=False,
     )
-    hashed_password: str = sqlalchemy.Column(
+    hashed_password: str = mapped_column(
         sqlalchemy.String(length=1024),
         nullable=True,
     )
@@ -819,8 +815,8 @@ class User(SQLAlchemyBaseUserTable[int], Base):
 class Team(PermissionsMixin, Base):
     __tablename__ = "teams"
 
-    id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
-    name = sqlalchemy.Column(sqlalchemy.Text, nullable=False, unique=True)
+    id = mapped_column(sqlalchemy.Integer, primary_key=True)
+    name = mapped_column(sqlalchemy.Text, nullable=False, unique=True)
     members = relationship(
         "User", secondary=TeamUserMapping, back_populates="teams"
     )
@@ -907,13 +903,13 @@ ProductPlatforms = sqlalchemy.Table(
 class Product(PermissionsMixin, TeamMixin, Base):
     __tablename__ = "products"
 
-    id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
-    name = sqlalchemy.Column(sqlalchemy.Text, nullable=False, unique=True)
+    id = mapped_column(sqlalchemy.Integer, primary_key=True)
+    name = mapped_column(sqlalchemy.Text, nullable=False, unique=True)
     # FIXME: change nullable to False after population
-    title = sqlalchemy.Column(sqlalchemy.String(100), nullable=True)
-    description = sqlalchemy.Column(sqlalchemy.Text, nullable=True)
+    title = mapped_column(sqlalchemy.String(100), nullable=True)
+    description = mapped_column(sqlalchemy.Text, nullable=True)
     team = relationship("Team", back_populates="products")
-    is_community = sqlalchemy.Column(
+    is_community = mapped_column(
         sqlalchemy.Boolean, nullable=False, default=True
     )
     roles = relationship("UserRole", secondary=ProductRoleMapping)
@@ -949,37 +945,37 @@ class Product(PermissionsMixin, TeamMixin, Base):
 class TestTask(TimeMixin, Base):
     __tablename__ = "test_tasks"
 
-    id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
-    package_name = sqlalchemy.Column(sqlalchemy.TEXT, nullable=False)
-    package_version = sqlalchemy.Column(sqlalchemy.TEXT, nullable=False)
-    package_release = sqlalchemy.Column(sqlalchemy.TEXT, nullable=True)
-    env_arch = sqlalchemy.Column(sqlalchemy.TEXT, nullable=False)
-    build_task_id = sqlalchemy.Column(
+    id = mapped_column(sqlalchemy.Integer, primary_key=True)
+    package_name = mapped_column(sqlalchemy.TEXT, nullable=False)
+    package_version = mapped_column(sqlalchemy.TEXT, nullable=False)
+    package_release = mapped_column(sqlalchemy.TEXT, nullable=True)
+    env_arch = mapped_column(sqlalchemy.TEXT, nullable=False)
+    build_task_id = mapped_column(
         sqlalchemy.Integer,
         sqlalchemy.ForeignKey("build_tasks.id"),
         nullable=False,
         index=True,
     )
     build_task = relationship("BuildTask", back_populates="test_tasks")
-    status = sqlalchemy.Column(
+    status = mapped_column(
         sqlalchemy.Integer,
         nullable=False,
         index=True,
     )
-    alts_response = sqlalchemy.Column(JSONB, nullable=True)
-    revision = sqlalchemy.Column(
+    alts_response = mapped_column(JSONB, nullable=True)
+    revision = mapped_column(
         sqlalchemy.Integer,
         nullable=False,
         index=True,
     )
     artifacts = relationship("TestTaskArtifact", back_populates="test_task")
-    repository_id = sqlalchemy.Column(
+    repository_id = mapped_column(
         sqlalchemy.Integer,
         sqlalchemy.ForeignKey("repositories.id", name="test_task_repo_fk"),
         nullable=True,
     )
     repository = relationship("Repository")
-    scheduled_at = sqlalchemy.Column(sqlalchemy.DateTime, nullable=True)
+    scheduled_at = mapped_column(sqlalchemy.DateTime, nullable=True)
     performance_stats: "PerformanceStats" = relationship(
         "PerformanceStats",
         back_populates="test_task",
@@ -988,15 +984,15 @@ class TestTask(TimeMixin, Base):
 
 class TestTaskArtifact(Base):
     __tablename__ = "test_task_artifacts"
-    id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
-    test_task_id = sqlalchemy.Column(
+    id = mapped_column(sqlalchemy.Integer, primary_key=True)
+    test_task_id = mapped_column(
         sqlalchemy.Integer,
         sqlalchemy.ForeignKey("test_tasks.id"),
         nullable=False,
     )
     test_task = relationship("TestTask", back_populates="artifacts")
-    name = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    href = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
+    name = mapped_column(sqlalchemy.Text, nullable=False)
+    href = mapped_column(sqlalchemy.Text, nullable=False)
 
 
 class PackageTestRepository(Base):
@@ -1008,11 +1004,11 @@ class PackageTestRepository(Base):
             name="package_test_repo_uix",
         ),
     ]
-    id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
-    package_name = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    folder_name = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    url = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    test_repository_id = sqlalchemy.Column(
+    id = mapped_column(sqlalchemy.Integer, primary_key=True)
+    package_name = mapped_column(sqlalchemy.Text, nullable=False)
+    folder_name = mapped_column(sqlalchemy.Text, nullable=False)
+    url = mapped_column(sqlalchemy.Text, nullable=False)
+    test_repository_id = mapped_column(
         sqlalchemy.Integer,
         sqlalchemy.ForeignKey(
             "test_repositories.id",
@@ -1026,11 +1022,11 @@ class PackageTestRepository(Base):
 
 class TestRepository(Base):
     __tablename__ = "test_repositories"
-    id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
-    name = sqlalchemy.Column(sqlalchemy.Text, nullable=False, unique=True)
-    url = sqlalchemy.Column(sqlalchemy.Text, nullable=False, unique=True)
-    tests_dir = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    tests_prefix = sqlalchemy.Column(sqlalchemy.Text, nullable=True)
+    id = mapped_column(sqlalchemy.Integer, primary_key=True)
+    name = mapped_column(sqlalchemy.Text, nullable=False, unique=True)
+    url = mapped_column(sqlalchemy.Text, nullable=False, unique=True)
+    tests_dir = mapped_column(sqlalchemy.Text, nullable=False)
+    tests_prefix = mapped_column(sqlalchemy.Text, nullable=True)
     packages: List["PackageTestRepository"] = relationship(
         "PackageTestRepository",
         back_populates="test_repository",
@@ -1041,29 +1037,29 @@ class TestRepository(Base):
 class Release(PermissionsMixin, TeamMixin, TimeMixin, Base):
     __tablename__ = "build_releases"
 
-    id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
-    build_ids = sqlalchemy.Column(
+    id = mapped_column(sqlalchemy.Integer, primary_key=True)
+    build_ids = mapped_column(
         sqlalchemy.ARRAY(sqlalchemy.Integer, dimensions=1), nullable=False
     )
-    created_at = sqlalchemy.Column(
+    created_at = mapped_column(
         sqlalchemy.DateTime,
         nullable=True,
         default=func.current_timestamp(),
     )
-    build_task_ids = sqlalchemy.Column(
+    build_task_ids = mapped_column(
         sqlalchemy.ARRAY(sqlalchemy.Integer, dimensions=1), nullable=True
     )
-    reference_platform_id = sqlalchemy.Column(
+    reference_platform_id = mapped_column(
         sqlalchemy.Integer,
         nullable=True,
     )
-    platform_id = sqlalchemy.Column(
+    platform_id = mapped_column(
         sqlalchemy.Integer,
         sqlalchemy.ForeignKey("platforms.id"),
         nullable=False,
     )
     platform = relationship("Platform")
-    product_id = sqlalchemy.Column(
+    product_id = mapped_column(
         sqlalchemy.Integer,
         sqlalchemy.ForeignKey(
             "products.id",
@@ -1072,10 +1068,8 @@ class Release(PermissionsMixin, TeamMixin, TimeMixin, Base):
         nullable=False,
     )
     product = relationship("Product")
-    plan = sqlalchemy.Column(JSONB, nullable=True)
-    status = sqlalchemy.Column(
-        sqlalchemy.Integer, default=ReleaseStatus.SCHEDULED
-    )
+    plan = mapped_column(JSONB, nullable=True)
+    status = mapped_column(sqlalchemy.Integer, default=ReleaseStatus.SCHEDULED)
     performance_stats: List["PerformanceStats"] = relationship(
         "PerformanceStats",
         back_populates="release",
@@ -1111,22 +1105,22 @@ SignKeyRoleMapping = sqlalchemy.Table(
 class SignKey(PermissionsMixin, Base):
     __tablename__ = "sign_keys"
 
-    id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
-    name = sqlalchemy.Column(sqlalchemy.Text)
+    id = mapped_column(sqlalchemy.Integer, primary_key=True)
+    name = mapped_column(sqlalchemy.Text)
     # FIXME: change nullable to False after population
-    is_community = sqlalchemy.Column(
+    is_community = mapped_column(
         sqlalchemy.Boolean,
         nullable=True,
         default=False,
     )
-    description = sqlalchemy.Column(sqlalchemy.Text, nullable=True)
-    keyid = sqlalchemy.Column(sqlalchemy.String(16), unique=True)
-    fingerprint = sqlalchemy.Column(sqlalchemy.String(40), unique=True)
-    public_url = sqlalchemy.Column(sqlalchemy.Text)
-    inserted = sqlalchemy.Column(
+    description = mapped_column(sqlalchemy.Text, nullable=True)
+    keyid = mapped_column(sqlalchemy.String(16), unique=True)
+    fingerprint = mapped_column(sqlalchemy.String(40), unique=True)
+    public_url = mapped_column(sqlalchemy.Text)
+    inserted = mapped_column(
         sqlalchemy.DateTime, default=datetime.datetime.utcnow()
     )
-    product_id = sqlalchemy.Column(
+    product_id = mapped_column(
         sqlalchemy.Integer,
         sqlalchemy.ForeignKey(
             'products.id',
@@ -1135,7 +1129,7 @@ class SignKey(PermissionsMixin, Base):
         nullable=True,
     )
     product = relationship('Product', back_populates='sign_keys')
-    platform_id = sqlalchemy.Column(
+    platform_id = mapped_column(
         sqlalchemy.Integer,
         sqlalchemy.ForeignKey(
             "platforms.id",
@@ -1154,11 +1148,11 @@ class SignKey(PermissionsMixin, Base):
 class GenKeyTask(Base):
     __tablename__ = "gen_key_tasks"
 
-    id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
-    status = sqlalchemy.Column(sqlalchemy.Integer, default=GenKeyStatus.IDLE)
-    error_message = sqlalchemy.Column(sqlalchemy.Text, nullable=True)
+    id = mapped_column(sqlalchemy.Integer, primary_key=True)
+    status = mapped_column(sqlalchemy.Integer, default=GenKeyStatus.IDLE)
+    error_message = mapped_column(sqlalchemy.Text, nullable=True)
     product = relationship("Product")
-    product_id = sqlalchemy.Column(
+    product_id = mapped_column(
         sqlalchemy.Integer,
         sqlalchemy.ForeignKey("products.id"),
         nullable=False,
@@ -1168,66 +1162,66 @@ class GenKeyTask(Base):
 class SignTask(TimeMixin, Base):
     __tablename__ = "sign_tasks"
 
-    id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
-    build_id = sqlalchemy.Column(
+    id = mapped_column(sqlalchemy.Integer, primary_key=True)
+    build_id = mapped_column(
         sqlalchemy.Integer, sqlalchemy.ForeignKey("builds.id"), nullable=False
     )
     build = relationship("Build")
-    sign_key_id = sqlalchemy.Column(
+    sign_key_id = mapped_column(
         sqlalchemy.Integer,
         sqlalchemy.ForeignKey("sign_keys.id"),
         nullable=False,
     )
     sign_key = relationship("SignKey")
-    status = sqlalchemy.Column(sqlalchemy.Integer, default=SignStatus.IDLE)
-    ts = sqlalchemy.Column(sqlalchemy.DateTime, nullable=True)
-    error_message = sqlalchemy.Column(sqlalchemy.Text, nullable=True)
-    log_href = sqlalchemy.Column(sqlalchemy.Text, nullable=True)
-    stats = sqlalchemy.Column(JSONB, nullable=True)
+    status = mapped_column(sqlalchemy.Integer, default=SignStatus.IDLE)
+    ts = mapped_column(sqlalchemy.DateTime, nullable=True)
+    error_message = mapped_column(sqlalchemy.Text, nullable=True)
+    log_href = mapped_column(sqlalchemy.Text, nullable=True)
+    stats = mapped_column(JSONB, nullable=True)
 
 
 class ExportTask(Base):
     __tablename__ = "export_tasks"
 
-    id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
-    name = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    status = sqlalchemy.Column(sqlalchemy.Integer, nullable=False)
-    exported_at = sqlalchemy.Column(sqlalchemy.DateTime, nullable=True)
+    id = mapped_column(sqlalchemy.Integer, primary_key=True)
+    name = mapped_column(sqlalchemy.Text, nullable=False)
+    status = mapped_column(sqlalchemy.Integer, nullable=False)
+    exported_at = mapped_column(sqlalchemy.DateTime, nullable=True)
 
 
 class RepoExporter(Base):
     __tablename__ = "repo_exporters"
 
-    id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
-    path = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    exported_id = sqlalchemy.Column(
+    id = mapped_column(sqlalchemy.Integer, primary_key=True)
+    path = mapped_column(sqlalchemy.Text, nullable=False)
+    exported_id = mapped_column(
         sqlalchemy.Integer,
         sqlalchemy.ForeignKey("export_tasks.id"),
         nullable=False,
     )
-    repository_id = sqlalchemy.Column(
+    repository_id = mapped_column(
         sqlalchemy.Integer,
         sqlalchemy.ForeignKey("repositories.id"),
         nullable=False,
     )
     repository = relationship("Repository")
-    fs_exporter_href = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
+    fs_exporter_href = mapped_column(sqlalchemy.Text, nullable=False)
 
 
 class PlatformFlavour(PermissionsMixin, Base):
     __tablename__ = "platform_flavours"
 
-    id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
-    name = sqlalchemy.Column(sqlalchemy.Text, nullable=False, unique=True)
-    modularity = sqlalchemy.Column(JSONB, nullable=True)
+    id = mapped_column(sqlalchemy.Integer, primary_key=True)
+    name = mapped_column(sqlalchemy.Text, nullable=False, unique=True)
+    modularity = mapped_column(JSONB, nullable=True)
     repos = relationship("Repository", secondary=FlavourRepo)
-    data = sqlalchemy.Column(JSONB, nullable=True)
+    data = mapped_column(JSONB, nullable=True)
 
 
 class NewErrataRecord(Base):
     __tablename__ = "new_errata_records"
-    id = sqlalchemy.Column(sqlalchemy.Text, primary_key=True)
-    platform_id = sqlalchemy.Column(
+    id = mapped_column(sqlalchemy.Text, primary_key=True)
+    platform_id = mapped_column(
         sqlalchemy.Integer,
         sqlalchemy.ForeignKey(
             "platforms.id",
@@ -1237,44 +1231,44 @@ class NewErrataRecord(Base):
         primary_key=True,
     )
     platform = relationship("Platform")
-    module = sqlalchemy.Column(sqlalchemy.Text, nullable=True)
-    release_status = sqlalchemy.Column(
+    module = mapped_column(sqlalchemy.Text, nullable=True)
+    release_status = mapped_column(
         sqlalchemy.Enum(ErrataReleaseStatus, name='erratareleasestatus'),
         nullable=False,
     )
-    last_release_log = sqlalchemy.Column(sqlalchemy.Text, nullable=True)
-    summary = sqlalchemy.Column(sqlalchemy.Text, nullable=True)
-    solution = sqlalchemy.Column(sqlalchemy.Text, nullable=True)
+    last_release_log = mapped_column(sqlalchemy.Text, nullable=True)
+    summary = mapped_column(sqlalchemy.Text, nullable=True)
+    solution = mapped_column(sqlalchemy.Text, nullable=True)
 
-    freezed = sqlalchemy.Column(sqlalchemy.Boolean, nullable=True)
+    freezed = mapped_column(sqlalchemy.Boolean, nullable=True)
 
-    issued_date = sqlalchemy.Column(sqlalchemy.DateTime, nullable=False)
-    updated_date = sqlalchemy.Column(sqlalchemy.DateTime, nullable=False)
-    description = sqlalchemy.Column(sqlalchemy.Text, nullable=True)
-    original_description = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    title = sqlalchemy.Column(sqlalchemy.Text, nullable=True)
-    oval_title = sqlalchemy.Column(sqlalchemy.Text, nullable=True)
-    original_title = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    contact_mail = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    status = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    version = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    severity = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    rights = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
+    issued_date = mapped_column(sqlalchemy.DateTime, nullable=False)
+    updated_date = mapped_column(sqlalchemy.DateTime, nullable=False)
+    description = mapped_column(sqlalchemy.Text, nullable=True)
+    original_description = mapped_column(sqlalchemy.Text, nullable=False)
+    title = mapped_column(sqlalchemy.Text, nullable=True)
+    oval_title = mapped_column(sqlalchemy.Text, nullable=True)
+    original_title = mapped_column(sqlalchemy.Text, nullable=False)
+    contact_mail = mapped_column(sqlalchemy.Text, nullable=False)
+    status = mapped_column(sqlalchemy.Text, nullable=False)
+    version = mapped_column(sqlalchemy.Text, nullable=False)
+    severity = mapped_column(sqlalchemy.Text, nullable=False)
+    rights = mapped_column(sqlalchemy.Text, nullable=False)
     # OVAL-only fields
-    definition_id = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    definition_version = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    definition_class = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    affected_cpe = sqlalchemy.Column(JSONB, nullable=False, default=[])
-    criteria = sqlalchemy.Column(JSONB, nullable=True)
-    original_criteria = sqlalchemy.Column(JSONB, nullable=True)
-    tests = sqlalchemy.Column(JSONB, nullable=True)
-    original_tests = sqlalchemy.Column(JSONB, nullable=True)
-    objects = sqlalchemy.Column(JSONB, nullable=True)
-    original_objects = sqlalchemy.Column(JSONB, nullable=True)
-    states = sqlalchemy.Column(JSONB, nullable=True)
-    original_states = sqlalchemy.Column(JSONB, nullable=True)
-    variables = sqlalchemy.Column(JSONB, nullable=True)
-    original_variables = sqlalchemy.Column(JSONB, nullable=True)
+    definition_id = mapped_column(sqlalchemy.Text, nullable=False)
+    definition_version = mapped_column(sqlalchemy.Text, nullable=False)
+    definition_class = mapped_column(sqlalchemy.Text, nullable=False)
+    affected_cpe = mapped_column(JSONB, nullable=False, default=[])
+    criteria = mapped_column(JSONB, nullable=True)
+    original_criteria = mapped_column(JSONB, nullable=True)
+    tests = mapped_column(JSONB, nullable=True)
+    original_tests = mapped_column(JSONB, nullable=True)
+    objects = mapped_column(JSONB, nullable=True)
+    original_objects = mapped_column(JSONB, nullable=True)
+    states = mapped_column(JSONB, nullable=True)
+    original_states = mapped_column(JSONB, nullable=True)
+    variables = mapped_column(JSONB, nullable=True)
+    original_variables = mapped_column(JSONB, nullable=True)
 
     references = relationship(
         "NewErrataReference",
@@ -1319,24 +1313,24 @@ class NewErrataPackage(Base):
         ),
     )
 
-    id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
-    errata_record_id = sqlalchemy.Column(sqlalchemy.Text)
-    platform_id = sqlalchemy.Column(sqlalchemy.Integer)
+    id = mapped_column(sqlalchemy.Integer, primary_key=True)
+    errata_record_id = mapped_column(sqlalchemy.Text)
+    platform_id = mapped_column(sqlalchemy.Integer)
     platform_specific_errata_record = relationship(
         "NewErrataRecord",
-        foreign_keys=str([errata_record_id, platform_id]),
+        foreign_keys=[errata_record_id, platform_id],
         cascade="all, delete",
         primaryjoin="and_(NewErrataPackage.errata_record_id == NewErrataRecord.id,"
         "NewErrataPackage.platform_id == NewErrataRecord.platform_id)",
         back_populates="packages",
     )
-    name = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    version = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    release = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    epoch = sqlalchemy.Column(sqlalchemy.Integer, nullable=False)
-    arch = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    source_srpm = sqlalchemy.Column(sqlalchemy.Text, nullable=True)
-    reboot_suggested = sqlalchemy.Column(sqlalchemy.Boolean, nullable=False)
+    name = mapped_column(sqlalchemy.Text, nullable=False)
+    version = mapped_column(sqlalchemy.Text, nullable=False)
+    release = mapped_column(sqlalchemy.Text, nullable=False)
+    epoch = mapped_column(sqlalchemy.Integer, nullable=False)
+    arch = mapped_column(sqlalchemy.Text, nullable=False)
+    source_srpm = mapped_column(sqlalchemy.Text, nullable=True)
+    reboot_suggested = mapped_column(sqlalchemy.Boolean, nullable=False)
     albs_packages = relationship(
         "NewErrataToALBSPackage",
         back_populates="errata_package",
@@ -1354,25 +1348,25 @@ class NewErrataReference(Base):
         ),
     )
 
-    id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
-    href = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    ref_id = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    title = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    ref_type = sqlalchemy.Column(
+    id = mapped_column(sqlalchemy.Integer, primary_key=True)
+    href = mapped_column(sqlalchemy.Text, nullable=False)
+    ref_id = mapped_column(sqlalchemy.Text, nullable=False)
+    title = mapped_column(sqlalchemy.Text, nullable=False)
+    ref_type = mapped_column(
         sqlalchemy.Enum(ErrataReferenceType), nullable=False
     )
-    errata_record_id = sqlalchemy.Column(sqlalchemy.Text)
-    platform_id = sqlalchemy.Column(sqlalchemy.Integer)
+    errata_record_id = mapped_column(sqlalchemy.Text)
+    platform_id = mapped_column(sqlalchemy.Integer)
     platform_specific_errata_record = relationship(
         "NewErrataRecord",
-        foreign_keys=str([errata_record_id, platform_id]),
+        foreign_keys=[errata_record_id, platform_id],
         cascade="all, delete",
         primaryjoin="and_(NewErrataReference.errata_record_id == NewErrataRecord.id,"
         "NewErrataReference.platform_id == NewErrataRecord.platform_id)",
         back_populates="references",
     )
     cve = relationship("ErrataCVE", cascade="all, delete")
-    cve_id = sqlalchemy.Column(
+    cve_id = mapped_column(
         sqlalchemy.Text,
         sqlalchemy.ForeignKey(
             "errata_cves.id",
@@ -1392,8 +1386,8 @@ class NewErrataToALBSPackage(Base):
         ),
     )
 
-    id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
-    errata_package_id = sqlalchemy.Column(
+    id = mapped_column(sqlalchemy.Integer, primary_key=True)
+    errata_package_id = mapped_column(
         sqlalchemy.Integer,
         sqlalchemy.ForeignKey(
             "new_errata_packages.id",
@@ -1407,7 +1401,7 @@ class NewErrataToALBSPackage(Base):
         "NewErrataPackage",
         back_populates="albs_packages",
     )
-    albs_artifact_id = sqlalchemy.Column(
+    albs_artifact_id = mapped_column(
         sqlalchemy.Integer,
         sqlalchemy.ForeignKey(
             "build_artifacts.id",
@@ -1417,17 +1411,17 @@ class NewErrataToALBSPackage(Base):
         nullable=True,
     )
     build_artifact: BuildTaskArtifact = relationship("BuildTaskArtifact")
-    pulp_href = sqlalchemy.Column(sqlalchemy.Text, nullable=True)
-    status = sqlalchemy.Column(
+    pulp_href = mapped_column(sqlalchemy.Text, nullable=True)
+    status = mapped_column(
         sqlalchemy.Enum(ErrataPackageStatus),
         nullable=False,
     )
 
-    name = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    arch = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    version = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    release = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    epoch = sqlalchemy.Column(sqlalchemy.Integer, nullable=False)
+    name = mapped_column(sqlalchemy.Text, nullable=False)
+    arch = mapped_column(sqlalchemy.Text, nullable=False)
+    version = mapped_column(sqlalchemy.Text, nullable=False)
+    release = mapped_column(sqlalchemy.Text, nullable=False)
+    epoch = mapped_column(sqlalchemy.Integer, nullable=False)
 
     @property
     def build_id(self):
@@ -1449,51 +1443,51 @@ class NewErrataToALBSPackage(Base):
 class ErrataRecord(Base):
     __tablename__ = "errata_records"
 
-    id = sqlalchemy.Column(sqlalchemy.Text, primary_key=True)
-    platform_id = sqlalchemy.Column(
+    id = mapped_column(sqlalchemy.Text, primary_key=True)
+    platform_id = mapped_column(
         sqlalchemy.Integer,
         sqlalchemy.ForeignKey("platforms.id"),
         nullable=False,
     )
     platform = relationship("Platform")
-    module = sqlalchemy.Column(sqlalchemy.Text, nullable=True)
-    release_status = sqlalchemy.Column(
+    module = mapped_column(sqlalchemy.Text, nullable=True)
+    release_status = mapped_column(
         sqlalchemy.Enum(ErrataReleaseStatus),
         nullable=True,
     )
-    last_release_log = sqlalchemy.Column(sqlalchemy.Text, nullable=True)
-    summary = sqlalchemy.Column(sqlalchemy.Text, nullable=True)
-    solution = sqlalchemy.Column(sqlalchemy.Text, nullable=True)
+    last_release_log = mapped_column(sqlalchemy.Text, nullable=True)
+    summary = mapped_column(sqlalchemy.Text, nullable=True)
+    solution = mapped_column(sqlalchemy.Text, nullable=True)
 
-    freezed = sqlalchemy.Column(sqlalchemy.Boolean, nullable=True)
+    freezed = mapped_column(sqlalchemy.Boolean, nullable=True)
 
-    issued_date = sqlalchemy.Column(sqlalchemy.DateTime, nullable=False)
-    updated_date = sqlalchemy.Column(sqlalchemy.DateTime, nullable=False)
-    description = sqlalchemy.Column(sqlalchemy.Text, nullable=True)
-    original_description = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    title = sqlalchemy.Column(sqlalchemy.Text, nullable=True)
-    oval_title = sqlalchemy.Column(sqlalchemy.Text, nullable=True)
-    original_title = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    contact_mail = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    status = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    version = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    severity = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    rights = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
+    issued_date = mapped_column(sqlalchemy.DateTime, nullable=False)
+    updated_date = mapped_column(sqlalchemy.DateTime, nullable=False)
+    description = mapped_column(sqlalchemy.Text, nullable=True)
+    original_description = mapped_column(sqlalchemy.Text, nullable=False)
+    title = mapped_column(sqlalchemy.Text, nullable=True)
+    oval_title = mapped_column(sqlalchemy.Text, nullable=True)
+    original_title = mapped_column(sqlalchemy.Text, nullable=False)
+    contact_mail = mapped_column(sqlalchemy.Text, nullable=False)
+    status = mapped_column(sqlalchemy.Text, nullable=False)
+    version = mapped_column(sqlalchemy.Text, nullable=False)
+    severity = mapped_column(sqlalchemy.Text, nullable=False)
+    rights = mapped_column(sqlalchemy.Text, nullable=False)
     # OVAL-only fields
-    definition_id = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    definition_version = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    definition_class = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    affected_cpe = sqlalchemy.Column(JSONB, nullable=False, default=[])
-    criteria = sqlalchemy.Column(JSONB, nullable=True)
-    original_criteria = sqlalchemy.Column(JSONB, nullable=True)
-    tests = sqlalchemy.Column(JSONB, nullable=True)
-    original_tests = sqlalchemy.Column(JSONB, nullable=True)
-    objects = sqlalchemy.Column(JSONB, nullable=True)
-    original_objects = sqlalchemy.Column(JSONB, nullable=True)
-    states = sqlalchemy.Column(JSONB, nullable=True)
-    original_states = sqlalchemy.Column(JSONB, nullable=True)
-    variables = sqlalchemy.Column(JSONB, nullable=True)
-    original_variables = sqlalchemy.Column(JSONB, nullable=True)
+    definition_id = mapped_column(sqlalchemy.Text, nullable=False)
+    definition_version = mapped_column(sqlalchemy.Text, nullable=False)
+    definition_class = mapped_column(sqlalchemy.Text, nullable=False)
+    affected_cpe = mapped_column(JSONB, nullable=False, default=[])
+    criteria = mapped_column(JSONB, nullable=True)
+    original_criteria = mapped_column(JSONB, nullable=True)
+    tests = mapped_column(JSONB, nullable=True)
+    original_tests = mapped_column(JSONB, nullable=True)
+    objects = mapped_column(JSONB, nullable=True)
+    original_objects = mapped_column(JSONB, nullable=True)
+    states = mapped_column(JSONB, nullable=True)
+    original_states = mapped_column(JSONB, nullable=True)
+    variables = mapped_column(JSONB, nullable=True)
+    original_variables = mapped_column(JSONB, nullable=True)
 
     references = relationship("ErrataReference", cascade="all, delete")
     packages = relationship("ErrataPackage", cascade="all, delete")
@@ -1525,14 +1519,14 @@ class ErrataRecord(Base):
 class ErrataReference(Base):
     __tablename__ = "errata_references"
 
-    id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
-    href = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    ref_id = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    title = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    ref_type = sqlalchemy.Column(
+    id = mapped_column(sqlalchemy.Integer, primary_key=True)
+    href = mapped_column(sqlalchemy.Text, nullable=False)
+    ref_id = mapped_column(sqlalchemy.Text, nullable=False)
+    title = mapped_column(sqlalchemy.Text, nullable=False)
+    ref_type = mapped_column(
         sqlalchemy.Enum(ErrataReferenceType), nullable=False
     )
-    errata_record_id = sqlalchemy.Column(
+    errata_record_id = mapped_column(
         sqlalchemy.Text,
         sqlalchemy.ForeignKey(
             "errata_records.id",
@@ -1543,7 +1537,7 @@ class ErrataReference(Base):
         index=True,
     )
     cve = relationship("ErrataCVE", cascade="all, delete")
-    cve_id = sqlalchemy.Column(
+    cve_id = mapped_column(
         sqlalchemy.Text,
         sqlalchemy.ForeignKey(
             "errata_cves.id",
@@ -1557,18 +1551,18 @@ class ErrataReference(Base):
 class ErrataCVE(Base):
     __tablename__ = "errata_cves"
 
-    id = sqlalchemy.Column(sqlalchemy.Text, primary_key=True)
-    cvss3 = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    cwe = sqlalchemy.Column(sqlalchemy.Text, nullable=True)
-    impact = sqlalchemy.Column(sqlalchemy.Text, nullable=True)
-    public = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
+    id = mapped_column(sqlalchemy.Text, primary_key=True)
+    cvss3 = mapped_column(sqlalchemy.Text, nullable=False)
+    cwe = mapped_column(sqlalchemy.Text, nullable=True)
+    impact = mapped_column(sqlalchemy.Text, nullable=True)
+    public = mapped_column(sqlalchemy.Text, nullable=False)
 
 
 class ErrataPackage(Base):
     __tablename__ = "errata_packages"
 
-    id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
-    errata_record_id = sqlalchemy.Column(
+    id = mapped_column(sqlalchemy.Integer, primary_key=True)
+    errata_record_id = mapped_column(
         sqlalchemy.Text,
         sqlalchemy.ForeignKey(
             "errata_records.id",
@@ -1578,13 +1572,13 @@ class ErrataPackage(Base):
         nullable=False,
         index=True,
     )
-    name = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    version = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    release = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    epoch = sqlalchemy.Column(sqlalchemy.Integer, nullable=False)
-    arch = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    source_srpm = sqlalchemy.Column(sqlalchemy.Text, nullable=True)
-    reboot_suggested = sqlalchemy.Column(sqlalchemy.Boolean, nullable=False)
+    name = mapped_column(sqlalchemy.Text, nullable=False)
+    version = mapped_column(sqlalchemy.Text, nullable=False)
+    release = mapped_column(sqlalchemy.Text, nullable=False)
+    epoch = mapped_column(sqlalchemy.Integer, nullable=False)
+    arch = mapped_column(sqlalchemy.Text, nullable=False)
+    source_srpm = mapped_column(sqlalchemy.Text, nullable=True)
+    reboot_suggested = mapped_column(sqlalchemy.Boolean, nullable=False)
     albs_packages = relationship(
         "ErrataToALBSPackage",
         back_populates="errata_package",
@@ -1601,8 +1595,8 @@ class ErrataToALBSPackage(Base):
         ),
     )
 
-    id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
-    errata_package_id = sqlalchemy.Column(
+    id = mapped_column(sqlalchemy.Integer, primary_key=True)
+    errata_package_id = mapped_column(
         sqlalchemy.Integer,
         sqlalchemy.ForeignKey(
             "errata_packages.id",
@@ -1616,7 +1610,7 @@ class ErrataToALBSPackage(Base):
         "ErrataPackage",
         back_populates="albs_packages",
     )
-    albs_artifact_id = sqlalchemy.Column(
+    albs_artifact_id = mapped_column(
         sqlalchemy.Integer,
         sqlalchemy.ForeignKey(
             "build_artifacts.id",
@@ -1626,17 +1620,17 @@ class ErrataToALBSPackage(Base):
         nullable=True,
     )
     build_artifact: BuildTaskArtifact = relationship("BuildTaskArtifact")
-    pulp_href = sqlalchemy.Column(sqlalchemy.Text, nullable=True)
-    status = sqlalchemy.Column(
+    pulp_href = mapped_column(sqlalchemy.Text, nullable=True)
+    status = mapped_column(
         sqlalchemy.Enum(ErrataPackageStatus),
         nullable=False,
     )
 
-    name = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    arch = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    version = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    release = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
-    epoch = sqlalchemy.Column(sqlalchemy.Integer, nullable=False)
+    name = mapped_column(sqlalchemy.Text, nullable=False)
+    arch = mapped_column(sqlalchemy.Text, nullable=False)
+    version = mapped_column(sqlalchemy.Text, nullable=False)
+    release = mapped_column(sqlalchemy.Text, nullable=False)
+    epoch = mapped_column(sqlalchemy.Integer, nullable=False)
 
     @property
     def build_id(self):
@@ -1657,12 +1651,12 @@ class ErrataToALBSPackage(Base):
 class PerformanceStats(Base):
     __tablename__ = "performance_stats"
 
-    id: int = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
-    statistics: Dict[str, Dict[str, Dict[str, str]]] = sqlalchemy.Column(
+    id: int = mapped_column(sqlalchemy.Integer, primary_key=True)
+    statistics: Dict[str, Dict[str, Dict[str, str]]] = mapped_column(
         JSONB,
         nullable=True,
     )
-    build_task_id: int = sqlalchemy.Column(
+    build_task_id: int = mapped_column(
         sqlalchemy.Integer,
         sqlalchemy.ForeignKey(
             "build_tasks.id",
@@ -1675,7 +1669,7 @@ class PerformanceStats(Base):
         "BuildTask",
         back_populates="performance_stats",
     )
-    test_task_id: int = sqlalchemy.Column(
+    test_task_id: int = mapped_column(
         sqlalchemy.Integer,
         sqlalchemy.ForeignKey("test_tasks.id", name="perf_stats_test_task_id"),
         nullable=True,
@@ -1685,7 +1679,7 @@ class PerformanceStats(Base):
         "TestTask",
         back_populates="performance_stats",
     )
-    release_id: int = sqlalchemy.Column(
+    release_id: int = mapped_column(
         sqlalchemy.Integer,
         sqlalchemy.ForeignKey(
             "build_releases.id",

--- a/alws/pulp_models.py
+++ b/alws/pulp_models.py
@@ -235,7 +235,7 @@ class CoreContent(PulpBase):
         "RpmPackage",
         back_populates="content",
     )
-    core_contentartifact: Mapped["CoreContentArtifact"] = relationship(
+    core_contentartifact: Mapped[List["CoreContentArtifact"]] = relationship(
         "CoreContentArtifact",
         back_populates="content",
     )
@@ -325,7 +325,7 @@ class CoreArtifact(PulpBase):
         sqlalchemy.DATETIME,
         default=datetime.datetime.now,
     )
-    core_contentartifact: Mapped[CoreContentArtifact] = relationship(
+    core_contentartifact: Mapped[List[CoreContentArtifact]] = relationship(
         CoreContentArtifact,
         back_populates="artifact",
     )

--- a/alws/pulp_models.py
+++ b/alws/pulp_models.py
@@ -1,10 +1,10 @@
+import datetime
 import uuid
-from datetime import datetime
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import sqlalchemy
 from sqlalchemy.dialects.postgresql import JSONB, UUID
-from sqlalchemy.orm import mapped_column, relationship
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from alws.database import PulpBase
 
@@ -12,96 +12,124 @@ from alws.database import PulpBase
 class UpdateRecord(PulpBase):
     __tablename__ = "rpm_updaterecord"
 
-    content_ptr_id = mapped_column(UUID(as_uuid=True), primary_key=True)
-    id = mapped_column(sqlalchemy.Text)
-    issued_date = mapped_column(sqlalchemy.Text)
-    updated_date = mapped_column(sqlalchemy.Text)
-    description = mapped_column(sqlalchemy.Text)
-    fromstr = mapped_column(sqlalchemy.Text)
-    status = mapped_column(sqlalchemy.Text)
-    title = mapped_column(sqlalchemy.Text)
-    summary = mapped_column(sqlalchemy.Text)
-    version = mapped_column(sqlalchemy.Text)
-    type = mapped_column(sqlalchemy.Text)
-    severity = mapped_column(sqlalchemy.Text)
-    solution = mapped_column(sqlalchemy.Text)
-    release = mapped_column(sqlalchemy.Text)
-    rights = mapped_column(sqlalchemy.Text)
-    pushcount = mapped_column(sqlalchemy.Text)
-    digest = mapped_column(sqlalchemy.Text)
-    reboot_suggested = mapped_column(sqlalchemy.Boolean)
+    content_ptr_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True
+    )
+    id: Mapped[str] = mapped_column(sqlalchemy.Text)
+    issued_date: Mapped[str] = mapped_column(sqlalchemy.Text)
+    updated_date: Mapped[str] = mapped_column(sqlalchemy.Text)
+    description: Mapped[str] = mapped_column(sqlalchemy.Text)
+    fromstr: Mapped[str] = mapped_column(sqlalchemy.Text)
+    status: Mapped[str] = mapped_column(sqlalchemy.Text)
+    title: Mapped[str] = mapped_column(sqlalchemy.Text)
+    summary: Mapped[str] = mapped_column(sqlalchemy.Text)
+    version: Mapped[str] = mapped_column(sqlalchemy.Text)
+    type: Mapped[str] = mapped_column(sqlalchemy.Text)
+    severity: Mapped[str] = mapped_column(sqlalchemy.Text)
+    solution: Mapped[str] = mapped_column(sqlalchemy.Text)
+    release: Mapped[str] = mapped_column(sqlalchemy.Text)
+    rights: Mapped[str] = mapped_column(sqlalchemy.Text)
+    pushcount: Mapped[str] = mapped_column(sqlalchemy.Text)
+    digest: Mapped[str] = mapped_column(sqlalchemy.Text)
+    reboot_suggested: Mapped[bool] = mapped_column(sqlalchemy.Boolean)
 
-    collections: List["UpdateCollection"] = relationship("UpdateCollection")
-    references: List["UpdateReference"] = relationship("UpdateReference")
+    collections: Mapped[List["UpdateCollection"]] = relationship(
+        "UpdateCollection"
+    )
+    references: Mapped[List["UpdateReference"]] = relationship(
+        "UpdateReference"
+    )
 
 
 class UpdateCollection(PulpBase):
     __tablename__ = "rpm_updatecollection"
 
-    pulp_id = mapped_column(UUID(as_uuid=True), primary_key=True)
-    pulp_created = mapped_column(sqlalchemy.DATETIME)
-    pulp_last_updated = mapped_column(sqlalchemy.DATETIME)
+    pulp_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True
+    )
+    pulp_created: Mapped[datetime.datetime] = mapped_column(
+        sqlalchemy.DATETIME
+    )
+    pulp_last_updated: Mapped[datetime.datetime] = mapped_column(
+        sqlalchemy.DATETIME
+    )
 
-    name = mapped_column(sqlalchemy.Text)
-    shortname = mapped_column(sqlalchemy.Text)
-    module = mapped_column(sqlalchemy.JSON, nullable=True)
+    name: Mapped[str] = mapped_column(sqlalchemy.Text)
+    shortname: Mapped[str] = mapped_column(sqlalchemy.Text)
+    module: Mapped[Optional[Dict[str, Any]]] = mapped_column(
+        sqlalchemy.JSON, nullable=True
+    )
 
-    update_record_id = mapped_column(
+    update_record_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         sqlalchemy.ForeignKey(UpdateRecord.content_ptr_id),
         nullable=False,
     )
-    packages: List["UpdatePackage"] = relationship("UpdatePackage")
+    packages: Mapped[List["UpdatePackage"]] = relationship("UpdatePackage")
 
 
 class UpdatePackage(PulpBase):
     __tablename__ = "rpm_updatecollectionpackage"
 
-    pulp_id = mapped_column(
+    pulp_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
     )
-    pulp_created = mapped_column(sqlalchemy.DATETIME, default=datetime.now)
-    pulp_last_updated = mapped_column(
-        sqlalchemy.DATETIME,
-        default=datetime.now,
+    pulp_created: Mapped[datetime.datetime] = mapped_column(
+        sqlalchemy.DATETIME, default=datetime.datetime.now
     )
-    arch = mapped_column(sqlalchemy.Text)
-    filename = mapped_column(sqlalchemy.Text)
-    name = mapped_column(sqlalchemy.Text)
-    version = mapped_column(sqlalchemy.Text)
-    release = mapped_column(sqlalchemy.Text)
-    epoch = mapped_column(sqlalchemy.Text)
-    reboot_suggested = mapped_column(sqlalchemy.Boolean, default=False)
-    relogin_suggested = mapped_column(sqlalchemy.Boolean, default=False)
-    restart_suggested = mapped_column(sqlalchemy.Boolean, default=False)
-    src = mapped_column(sqlalchemy.Text)
-    sum = mapped_column(sqlalchemy.Text)
-    update_collection_id = mapped_column(
+    pulp_last_updated: Mapped[datetime.datetime] = mapped_column(
+        sqlalchemy.DATETIME,
+        default=datetime.datetime.now,
+    )
+    arch: Mapped[str] = mapped_column(sqlalchemy.Text)
+    filename: Mapped[str] = mapped_column(sqlalchemy.Text)
+    name: Mapped[str] = mapped_column(sqlalchemy.Text)
+    version: Mapped[str] = mapped_column(sqlalchemy.Text)
+    release: Mapped[str] = mapped_column(sqlalchemy.Text)
+    epoch: Mapped[str] = mapped_column(sqlalchemy.Text)
+    reboot_suggested: Mapped[bool] = mapped_column(
+        sqlalchemy.Boolean, default=False
+    )
+    relogin_suggested: Mapped[bool] = mapped_column(
+        sqlalchemy.Boolean, default=False
+    )
+    restart_suggested: Mapped[bool] = mapped_column(
+        sqlalchemy.Boolean, default=False
+    )
+    src: Mapped[str] = mapped_column(sqlalchemy.Text)
+    sum: Mapped[str] = mapped_column(sqlalchemy.Text)
+    update_collection_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         sqlalchemy.ForeignKey(UpdateCollection.pulp_id),
         nullable=False,
     )
-    sum_type = mapped_column(sqlalchemy.Integer)
+    sum_type: Mapped[int] = mapped_column(sqlalchemy.Integer)
 
 
 class UpdateReference(PulpBase):
     __tablename__ = "rpm_updatereference"
 
-    pulp_id = mapped_column(
+    pulp_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
     )
-    pulp_created = mapped_column(sqlalchemy.DATETIME, default=datetime.now)
-    pulp_last_updated = mapped_column(
-        sqlalchemy.DATETIME,
-        default=datetime.now,
+    pulp_created: Mapped[datetime.datetime] = mapped_column(
+        sqlalchemy.DATETIME, default=datetime.datetime.now
     )
-    href = mapped_column(sqlalchemy.Text)
-    ref_id = mapped_column(sqlalchemy.Text, nullable=True)
-    title = mapped_column(sqlalchemy.Text, nullable=True)
-    ref_type = mapped_column(sqlalchemy.Text)
-    update_record_id = mapped_column(
+    pulp_last_updated: Mapped[datetime.datetime] = mapped_column(
+        sqlalchemy.DATETIME,
+        default=datetime.datetime.now,
+    )
+    href: Mapped[str] = mapped_column(sqlalchemy.Text)
+    ref_id: Mapped[Optional[str]] = mapped_column(
+        sqlalchemy.Text, nullable=True
+    )
+    title: Mapped[Optional[str]] = mapped_column(
+        sqlalchemy.Text, nullable=True
+    )
+    ref_type: Mapped[str] = mapped_column(sqlalchemy.Text)
+    update_record_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         sqlalchemy.ForeignKey(UpdateRecord.content_ptr_id),
         nullable=False,
@@ -111,29 +139,37 @@ class UpdateReference(PulpBase):
 class CoreRepository(PulpBase):
     __tablename__ = "core_repository"
 
-    pulp_id = mapped_column(
+    pulp_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
     )
-    pulp_created = mapped_column(sqlalchemy.DATETIME, default=datetime.now)
-    pulp_last_updated = mapped_column(
-        sqlalchemy.DATETIME,
-        default=datetime.now,
+    pulp_created: Mapped[datetime.datetime] = mapped_column(
+        sqlalchemy.DATETIME, default=datetime.datetime.now
     )
-    name = mapped_column(sqlalchemy.Text)
-    description = mapped_column(sqlalchemy.Text, nullable=True)
-    next_version = mapped_column(sqlalchemy.Integer)
-    pulp_type = mapped_column(sqlalchemy.Text)
-    remote_id = mapped_column(UUID(as_uuid=True), nullable=True)
-    retain_repo_versions = mapped_column(sqlalchemy.Integer, nullable=True)
-    user_hidden = mapped_column(sqlalchemy.Boolean)
+    pulp_last_updated: Mapped[datetime.datetime] = mapped_column(
+        sqlalchemy.DATETIME,
+        default=datetime.datetime.now,
+    )
+    name: Mapped[str] = mapped_column(sqlalchemy.Text)
+    description: Mapped[Optional[str]] = mapped_column(
+        sqlalchemy.Text, nullable=True
+    )
+    next_version: Mapped[int] = mapped_column(sqlalchemy.Integer)
+    pulp_type: Mapped[str] = mapped_column(sqlalchemy.Text)
+    remote_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True), nullable=True
+    )
+    retain_repo_versions: Mapped[Optional[int]] = mapped_column(
+        sqlalchemy.Integer, nullable=True
+    )
+    user_hidden: Mapped[bool] = mapped_column(sqlalchemy.Boolean)
 
-    repository_content = relationship(
+    repository_content: Mapped["CoreRepositoryContent"] = relationship(
         "CoreRepositoryContent",
         back_populates="repository",
     )
-    versions = relationship(
+    versions: Mapped[List["CoreRepositoryVersion"]] = relationship(
         "CoreRepositoryVersion",
         back_populates="repository",
     )
@@ -142,26 +178,30 @@ class CoreRepository(PulpBase):
 class CoreRepositoryVersion(PulpBase):
     __tablename__ = "core_repositoryversion"
 
-    pulp_id = mapped_column(
+    pulp_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
     )
-    pulp_created = mapped_column(sqlalchemy.DATETIME, default=datetime.now)
-    pulp_last_updated = mapped_column(
-        sqlalchemy.DATETIME,
-        default=datetime.now,
+    pulp_created: Mapped[datetime.datetime] = mapped_column(
+        sqlalchemy.DATETIME, default=datetime.datetime.now
     )
-    number = mapped_column(sqlalchemy.Integer)
-    complete = mapped_column(sqlalchemy.Boolean)
-    base_version_id = mapped_column(UUID(as_uuid=True), nullable=True)
-    repository_id = mapped_column(
+    pulp_last_updated: Mapped[datetime.datetime] = mapped_column(
+        sqlalchemy.DATETIME,
+        default=datetime.datetime.now,
+    )
+    number: Mapped[int] = mapped_column(sqlalchemy.Integer)
+    complete: Mapped[bool] = mapped_column(sqlalchemy.Boolean)
+    base_version_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True), nullable=True
+    )
+    repository_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         sqlalchemy.ForeignKey(CoreRepository.pulp_id),
     )
-    info = mapped_column(JSONB)
+    info: Mapped[Dict[str, Any]] = mapped_column(JSONB)
 
-    repository = relationship(
+    repository: Mapped[CoreRepository] = relationship(
         CoreRepository,
         back_populates="versions",
     )
@@ -170,34 +210,36 @@ class CoreRepositoryVersion(PulpBase):
 class CoreContent(PulpBase):
     __tablename__ = "core_content"
 
-    pulp_id = mapped_column(
+    pulp_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
     )
-    pulp_created = mapped_column(sqlalchemy.DATETIME, default=datetime.now)
-    pulp_last_updated = mapped_column(
-        sqlalchemy.DATETIME,
-        default=datetime.now,
+    pulp_created: Mapped[datetime.datetime] = mapped_column(
+        sqlalchemy.DATETIME, default=datetime.datetime.now
     )
-    pulp_type = mapped_column(sqlalchemy.Text)
-    upstream_id = mapped_column(
+    pulp_last_updated: Mapped[datetime.datetime] = mapped_column(
+        sqlalchemy.DATETIME,
+        default=datetime.datetime.now,
+    )
+    pulp_type: Mapped[str] = mapped_column(sqlalchemy.Text)
+    upstream_id: Mapped[Optional[uuid.UUID]] = mapped_column(
         UUID(as_uuid=True),
         nullable=True,
     )
-    timestamp_of_interest = mapped_column(
+    timestamp_of_interest: Mapped[datetime.datetime] = mapped_column(
         sqlalchemy.DATETIME,
-        default=datetime.now,
+        default=datetime.datetime.now,
     )
-    rpm_package: "RpmPackage" = relationship(
+    rpm_package: Mapped["RpmPackage"] = relationship(
         "RpmPackage",
         back_populates="content",
     )
-    core_contentartifact: "CoreContentArtifact" = relationship(
+    core_contentartifact: Mapped["CoreContentArtifact"] = relationship(
         "CoreContentArtifact",
         back_populates="content",
     )
-    core_repositorycontent: "CoreRepositoryContent" = relationship(
+    core_repositorycontent: Mapped["CoreRepositoryContent"] = relationship(
         "CoreRepositoryContent",
         back_populates="content",
     )
@@ -210,33 +252,35 @@ class CoreContent(PulpBase):
 class CoreContentArtifact(PulpBase):
     __tablename__ = "core_contentartifact"
 
-    pulp_id = mapped_column(
+    pulp_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
     )
-    pulp_created = mapped_column(sqlalchemy.DATETIME, default=datetime.now)
-    pulp_last_updated = mapped_column(
+    pulp_created: Mapped[datetime.datetime] = mapped_column(
+        sqlalchemy.DATETIME, default=datetime.datetime.now
+    )
+    pulp_last_updated: Mapped[Optional[datetime.datetime]] = mapped_column(
         sqlalchemy.DATETIME,
-        default=datetime.now,
+        default=datetime.datetime.now,
         nullable=True,
     )
-    relative_path = mapped_column(sqlalchemy.Text)
-    artifact_id = mapped_column(
+    relative_path: Mapped[Optional[uuid.UUID]] = mapped_column(sqlalchemy.Text)
+    artifact_id: Mapped[Optional[uuid.UUID]] = mapped_column(
         UUID(as_uuid=True),
         sqlalchemy.ForeignKey("core_artifact.pulp_id"),
         nullable=True,
     )
-    content_id = mapped_column(
+    content_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         sqlalchemy.ForeignKey(CoreContent.pulp_id),
     )
-    artifact: "CoreArtifact" = relationship(
+    artifact: Mapped["CoreArtifact"] = relationship(
         "CoreArtifact",
         foreign_keys=[artifact_id],
         back_populates="core_contentartifact",
     )
-    content: CoreContent = relationship(
+    content: Mapped[CoreContent] = relationship(
         CoreContent,
         foreign_keys=[content_id],
         back_populates="core_contentartifact",
@@ -246,30 +290,42 @@ class CoreContentArtifact(PulpBase):
 class CoreArtifact(PulpBase):
     __tablename__ = "core_artifact"
 
-    pulp_id = mapped_column(
+    pulp_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
     )
-    pulp_created = mapped_column(sqlalchemy.DATETIME, default=datetime.now)
-    pulp_last_updated = mapped_column(
+    pulp_created: Mapped[datetime.datetime] = mapped_column(
+        sqlalchemy.DATETIME, default=datetime.datetime.now
+    )
+    pulp_last_updated: Mapped[Optional[datetime.datetime]] = mapped_column(
         sqlalchemy.DATETIME,
-        default=datetime.now,
+        default=datetime.datetime.now,
         nullable=True,
     )
-    file = mapped_column(sqlalchemy.VARCHAR(255))
-    size = mapped_column(sqlalchemy.BigInteger)
-    md5 = mapped_column(sqlalchemy.VARCHAR(32), nullable=True)
-    sha1 = mapped_column(sqlalchemy.VARCHAR(40), nullable=True)
-    sha224 = mapped_column(sqlalchemy.VARCHAR(56), nullable=True)
-    sha256 = mapped_column(sqlalchemy.VARCHAR(64))
-    sha384 = mapped_column(sqlalchemy.VARCHAR(96), nullable=True)
-    sha512 = mapped_column(sqlalchemy.VARCHAR(128), nullable=True)
-    timestamp_of_interest = mapped_column(
-        sqlalchemy.DATETIME,
-        default=datetime.now,
+    file: Mapped[str] = mapped_column(sqlalchemy.VARCHAR(255))
+    size: Mapped[int] = mapped_column(sqlalchemy.BigInteger)
+    md5: Mapped[Optional[str]] = mapped_column(
+        sqlalchemy.VARCHAR(32), nullable=True
     )
-    core_contentartifact: CoreContentArtifact = relationship(
+    sha1: Mapped[Optional[str]] = mapped_column(
+        sqlalchemy.VARCHAR(40), nullable=True
+    )
+    sha224: Mapped[Optional[str]] = mapped_column(
+        sqlalchemy.VARCHAR(56), nullable=True
+    )
+    sha256: Mapped[str] = mapped_column(sqlalchemy.VARCHAR(64))
+    sha384: Mapped[Optional[str]] = mapped_column(
+        sqlalchemy.VARCHAR(96), nullable=True
+    )
+    sha512: Mapped[Optional[str]] = mapped_column(
+        sqlalchemy.VARCHAR(128), nullable=True
+    )
+    timestamp_of_interest: Mapped[datetime.datetime] = mapped_column(
+        sqlalchemy.DATETIME,
+        default=datetime.datetime.now,
+    )
+    core_contentartifact: Mapped[CoreContentArtifact] = relationship(
         CoreContentArtifact,
         back_populates="artifact",
     )
@@ -278,49 +334,51 @@ class CoreArtifact(PulpBase):
 class CoreRepositoryContent(PulpBase):
     __tablename__ = "core_repositorycontent"
 
-    pulp_id = mapped_column(
+    pulp_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
     )
-    pulp_created = mapped_column(sqlalchemy.DATETIME, default=datetime.now)
-    pulp_last_updated = mapped_column(
-        sqlalchemy.DATETIME,
-        default=datetime.now,
+    pulp_created: Mapped[datetime.datetime] = mapped_column(
+        sqlalchemy.DATETIME, default=datetime.datetime.now
     )
-    content_id = mapped_column(
+    pulp_last_updated: Mapped[datetime.datetime] = mapped_column(
+        sqlalchemy.DATETIME,
+        default=datetime.datetime.now,
+    )
+    content_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         sqlalchemy.ForeignKey(CoreContent.pulp_id),
     )
-    repository_id = mapped_column(
+    repository_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         sqlalchemy.ForeignKey(CoreRepository.pulp_id),
     )
-    version_added_id = mapped_column(
+    version_added_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         sqlalchemy.ForeignKey(CoreRepositoryVersion.pulp_id),
     )
-    version_removed_id = mapped_column(
+    version_removed_id: Mapped[Optional[uuid.UUID]] = mapped_column(
         UUID(as_uuid=True),
         sqlalchemy.ForeignKey(CoreRepositoryVersion.pulp_id),
         nullable=True,
     )
 
-    content: List[CoreContent] = relationship(
+    content: Mapped[List[CoreContent]] = relationship(
         CoreContent,
         foreign_keys=[content_id],
         back_populates="core_repositorycontent",
     )
-    repository: List[CoreRepository] = relationship(
+    repository: Mapped[List[CoreRepository]] = relationship(
         CoreRepository,
         foreign_keys=[repository_id],
         back_populates="repository_content",
     )
-    added_version: List[CoreRepositoryVersion] = relationship(
+    added_version: Mapped[List[CoreRepositoryVersion]] = relationship(
         CoreRepositoryVersion,
         foreign_keys=[version_added_id],
     )
-    removed_version: List[CoreRepositoryVersion] = relationship(
+    removed_version: Mapped[List[CoreRepositoryVersion]] = relationship(
         CoreRepositoryVersion,
         foreign_keys=[version_removed_id],
     )
@@ -334,16 +392,16 @@ class RpmPackage(PulpBase):
         sqlalchemy.ForeignKey(CoreContent.pulp_id),
         primary_key=True,
     )
-    name = mapped_column(sqlalchemy.VARCHAR(255))
-    epoch = mapped_column(sqlalchemy.VARCHAR(10))
-    version = mapped_column(sqlalchemy.VARCHAR(255))
-    release = mapped_column(sqlalchemy.VARCHAR(255))
-    arch = mapped_column(sqlalchemy.VARCHAR(20))
-    pkgId = mapped_column(sqlalchemy.Text)
-    checksum_type = mapped_column(sqlalchemy.Text)
-    summary = mapped_column(sqlalchemy.Text)
-    description = mapped_column(sqlalchemy.Text)
-    url = mapped_column(sqlalchemy.Text)
+    name: Mapped[str] = mapped_column(sqlalchemy.VARCHAR(255))
+    epoch: Mapped[str] = mapped_column(sqlalchemy.VARCHAR(10))
+    version: Mapped[str] = mapped_column(sqlalchemy.VARCHAR(255))
+    release: Mapped[str] = mapped_column(sqlalchemy.VARCHAR(255))
+    arch: Mapped[str] = mapped_column(sqlalchemy.VARCHAR(20))
+    pkgId: Mapped[str] = mapped_column(sqlalchemy.Text)
+    checksum_type: Mapped[str] = mapped_column(sqlalchemy.Text)
+    summary: Mapped[str] = mapped_column(sqlalchemy.Text)
+    description: Mapped[str] = mapped_column(sqlalchemy.Text)
+    url: Mapped[str] = mapped_column(sqlalchemy.Text)
     # changelogs = mapped_column(JSONB)
     # files = mapped_column(JSONB)
     # requires = mapped_column(JSONB)
@@ -354,24 +412,38 @@ class RpmPackage(PulpBase):
     # enhances = mapped_column(JSONB)
     # recommends = mapped_column(JSONB)
     # supplements = mapped_column(JSONB)
-    location_base = mapped_column(sqlalchemy.Text)
-    location_href = mapped_column(sqlalchemy.Text)
-    rpm_buildhost = mapped_column(sqlalchemy.Text)
-    rpm_group = mapped_column(sqlalchemy.Text)
-    rpm_license = mapped_column(sqlalchemy.Text)
-    rpm_packager = mapped_column(sqlalchemy.Text)
-    rpm_sourcerpm = mapped_column(sqlalchemy.Text)
-    rpm_vendor = mapped_column(sqlalchemy.Text)
-    rpm_header_start = mapped_column(sqlalchemy.BigInteger, nullable=True)
-    rpm_header_end = mapped_column(sqlalchemy.BigInteger, nullable=True)
-    is_modular = mapped_column(sqlalchemy.Boolean)
-    size_archive = mapped_column(sqlalchemy.BigInteger, nullable=True)
-    size_installed = mapped_column(sqlalchemy.BigInteger, nullable=True)
-    size_package = mapped_column(sqlalchemy.BigInteger, nullable=True)
-    time_build = mapped_column(sqlalchemy.BigInteger, nullable=True)
-    time_file = mapped_column(sqlalchemy.BigInteger, nullable=True)
+    location_base: Mapped[str] = mapped_column(sqlalchemy.Text)
+    location_href: Mapped[str] = mapped_column(sqlalchemy.Text)
+    rpm_buildhost: Mapped[str] = mapped_column(sqlalchemy.Text)
+    rpm_group: Mapped[str] = mapped_column(sqlalchemy.Text)
+    rpm_license: Mapped[str] = mapped_column(sqlalchemy.Text)
+    rpm_packager: Mapped[str] = mapped_column(sqlalchemy.Text)
+    rpm_sourcerpm: Mapped[str] = mapped_column(sqlalchemy.Text)
+    rpm_vendor: Mapped[str] = mapped_column(sqlalchemy.Text)
+    rpm_header_start: Mapped[Optional[int]] = mapped_column(
+        sqlalchemy.BigInteger, nullable=True
+    )
+    rpm_header_end: Mapped[Optional[int]] = mapped_column(
+        sqlalchemy.BigInteger, nullable=True
+    )
+    is_modular: Mapped[bool] = mapped_column(sqlalchemy.Boolean)
+    size_archive: Mapped[Optional[int]] = mapped_column(
+        sqlalchemy.BigInteger, nullable=True
+    )
+    size_installed: Mapped[Optional[int]] = mapped_column(
+        sqlalchemy.BigInteger, nullable=True
+    )
+    size_package: Mapped[Optional[int]] = mapped_column(
+        sqlalchemy.BigInteger, nullable=True
+    )
+    time_build: Mapped[Optional[int]] = mapped_column(
+        sqlalchemy.BigInteger, nullable=True
+    )
+    time_file: Mapped[Optional[int]] = mapped_column(
+        sqlalchemy.BigInteger, nullable=True
+    )
 
-    content: CoreContent = relationship(
+    content: Mapped[CoreContent] = relationship(
         CoreContent,
         back_populates="rpm_package",
     )
@@ -412,16 +484,16 @@ class RpmPackage(PulpBase):
 class RpmModulemd(PulpBase):
     __tablename__ = "rpm_modulemd"
 
-    content_ptr_id = mapped_column(
+    content_ptr_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         sqlalchemy.ForeignKey(CoreContent.pulp_id),
         primary_key=True,
     )
-    name = mapped_column(sqlalchemy.Text)
-    stream = mapped_column(sqlalchemy.Text)
-    version = mapped_column(sqlalchemy.Text)
-    context = mapped_column(sqlalchemy.Text)
-    arch = mapped_column(sqlalchemy.Text)
+    name: Mapped[str] = mapped_column(sqlalchemy.Text)
+    stream: Mapped[str] = mapped_column(sqlalchemy.Text)
+    version: Mapped[str] = mapped_column(sqlalchemy.Text)
+    context: Mapped[str] = mapped_column(sqlalchemy.Text)
+    arch: Mapped[str] = mapped_column(sqlalchemy.Text)
 
     @property
     def nsvca(self):
@@ -431,12 +503,12 @@ class RpmModulemd(PulpBase):
 class RpmModulemdPackages(PulpBase):
     __tablename__ = "rpm_modulemd_packages"
 
-    id = mapped_column(sqlalchemy.Integer, primary_key=True)
-    modulemd_id = mapped_column(
+    id: Mapped[int] = mapped_column(sqlalchemy.Integer, primary_key=True)
+    modulemd_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         sqlalchemy.ForeignKey(RpmModulemd.content_ptr_id),
     )
-    package_id = mapped_column(
+    package_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         sqlalchemy.ForeignKey(RpmPackage.content_ptr_id),
     )

--- a/alws/pulp_models.py
+++ b/alws/pulp_models.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List
 
 import sqlalchemy
 from sqlalchemy.dialects.postgresql import JSONB, UUID
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import mapped_column, relationship
 
 from alws.database import PulpBase
 
@@ -12,24 +12,24 @@ from alws.database import PulpBase
 class UpdateRecord(PulpBase):
     __tablename__ = "rpm_updaterecord"
 
-    content_ptr_id = sqlalchemy.Column(UUID(as_uuid=True), primary_key=True)
-    id = sqlalchemy.Column(sqlalchemy.Text)
-    issued_date = sqlalchemy.Column(sqlalchemy.Text)
-    updated_date = sqlalchemy.Column(sqlalchemy.Text)
-    description = sqlalchemy.Column(sqlalchemy.Text)
-    fromstr = sqlalchemy.Column(sqlalchemy.Text)
-    status = sqlalchemy.Column(sqlalchemy.Text)
-    title = sqlalchemy.Column(sqlalchemy.Text)
-    summary = sqlalchemy.Column(sqlalchemy.Text)
-    version = sqlalchemy.Column(sqlalchemy.Text)
-    type = sqlalchemy.Column(sqlalchemy.Text)
-    severity = sqlalchemy.Column(sqlalchemy.Text)
-    solution = sqlalchemy.Column(sqlalchemy.Text)
-    release = sqlalchemy.Column(sqlalchemy.Text)
-    rights = sqlalchemy.Column(sqlalchemy.Text)
-    pushcount = sqlalchemy.Column(sqlalchemy.Text)
-    digest = sqlalchemy.Column(sqlalchemy.Text)
-    reboot_suggested = sqlalchemy.Column(sqlalchemy.Boolean)
+    content_ptr_id = mapped_column(UUID(as_uuid=True), primary_key=True)
+    id = mapped_column(sqlalchemy.Text)
+    issued_date = mapped_column(sqlalchemy.Text)
+    updated_date = mapped_column(sqlalchemy.Text)
+    description = mapped_column(sqlalchemy.Text)
+    fromstr = mapped_column(sqlalchemy.Text)
+    status = mapped_column(sqlalchemy.Text)
+    title = mapped_column(sqlalchemy.Text)
+    summary = mapped_column(sqlalchemy.Text)
+    version = mapped_column(sqlalchemy.Text)
+    type = mapped_column(sqlalchemy.Text)
+    severity = mapped_column(sqlalchemy.Text)
+    solution = mapped_column(sqlalchemy.Text)
+    release = mapped_column(sqlalchemy.Text)
+    rights = mapped_column(sqlalchemy.Text)
+    pushcount = mapped_column(sqlalchemy.Text)
+    digest = mapped_column(sqlalchemy.Text)
+    reboot_suggested = mapped_column(sqlalchemy.Boolean)
 
     collections: List["UpdateCollection"] = relationship("UpdateCollection")
     references: List["UpdateReference"] = relationship("UpdateReference")
@@ -38,15 +38,15 @@ class UpdateRecord(PulpBase):
 class UpdateCollection(PulpBase):
     __tablename__ = "rpm_updatecollection"
 
-    pulp_id = sqlalchemy.Column(UUID(as_uuid=True), primary_key=True)
-    pulp_created = sqlalchemy.Column(sqlalchemy.DATETIME)
-    pulp_last_updated = sqlalchemy.Column(sqlalchemy.DATETIME)
+    pulp_id = mapped_column(UUID(as_uuid=True), primary_key=True)
+    pulp_created = mapped_column(sqlalchemy.DATETIME)
+    pulp_last_updated = mapped_column(sqlalchemy.DATETIME)
 
-    name = sqlalchemy.Column(sqlalchemy.Text)
-    shortname = sqlalchemy.Column(sqlalchemy.Text)
-    module = sqlalchemy.Column(sqlalchemy.JSON, nullable=True)
+    name = mapped_column(sqlalchemy.Text)
+    shortname = mapped_column(sqlalchemy.Text)
+    module = mapped_column(sqlalchemy.JSON, nullable=True)
 
-    update_record_id = sqlalchemy.Column(
+    update_record_id = mapped_column(
         UUID(as_uuid=True),
         sqlalchemy.ForeignKey(UpdateRecord.content_ptr_id),
         nullable=False,
@@ -57,51 +57,51 @@ class UpdateCollection(PulpBase):
 class UpdatePackage(PulpBase):
     __tablename__ = "rpm_updatecollectionpackage"
 
-    pulp_id = sqlalchemy.Column(
+    pulp_id = mapped_column(
         UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
     )
-    pulp_created = sqlalchemy.Column(sqlalchemy.DATETIME, default=datetime.now)
-    pulp_last_updated = sqlalchemy.Column(
+    pulp_created = mapped_column(sqlalchemy.DATETIME, default=datetime.now)
+    pulp_last_updated = mapped_column(
         sqlalchemy.DATETIME,
         default=datetime.now,
     )
-    arch = sqlalchemy.Column(sqlalchemy.Text)
-    filename = sqlalchemy.Column(sqlalchemy.Text)
-    name = sqlalchemy.Column(sqlalchemy.Text)
-    version = sqlalchemy.Column(sqlalchemy.Text)
-    release = sqlalchemy.Column(sqlalchemy.Text)
-    epoch = sqlalchemy.Column(sqlalchemy.Text)
-    reboot_suggested = sqlalchemy.Column(sqlalchemy.Boolean, default=False)
-    relogin_suggested = sqlalchemy.Column(sqlalchemy.Boolean, default=False)
-    restart_suggested = sqlalchemy.Column(sqlalchemy.Boolean, default=False)
-    src = sqlalchemy.Column(sqlalchemy.Text)
-    sum = sqlalchemy.Column(sqlalchemy.Text)
-    update_collection_id = sqlalchemy.Column(
+    arch = mapped_column(sqlalchemy.Text)
+    filename = mapped_column(sqlalchemy.Text)
+    name = mapped_column(sqlalchemy.Text)
+    version = mapped_column(sqlalchemy.Text)
+    release = mapped_column(sqlalchemy.Text)
+    epoch = mapped_column(sqlalchemy.Text)
+    reboot_suggested = mapped_column(sqlalchemy.Boolean, default=False)
+    relogin_suggested = mapped_column(sqlalchemy.Boolean, default=False)
+    restart_suggested = mapped_column(sqlalchemy.Boolean, default=False)
+    src = mapped_column(sqlalchemy.Text)
+    sum = mapped_column(sqlalchemy.Text)
+    update_collection_id = mapped_column(
         UUID(as_uuid=True),
         sqlalchemy.ForeignKey(UpdateCollection.pulp_id),
         nullable=False,
     )
-    sum_type = sqlalchemy.Column(sqlalchemy.Integer)
+    sum_type = mapped_column(sqlalchemy.Integer)
 
 
 class UpdateReference(PulpBase):
     __tablename__ = "rpm_updatereference"
 
-    pulp_id = sqlalchemy.Column(
+    pulp_id = mapped_column(
         UUID(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
     )
-    pulp_created = sqlalchemy.Column(sqlalchemy.DATETIME, default=datetime.now)
-    pulp_last_updated = sqlalchemy.Column(
+    pulp_created = mapped_column(sqlalchemy.DATETIME, default=datetime.now)
+    pulp_last_updated = mapped_column(
         sqlalchemy.DATETIME,
         default=datetime.now,
     )
-    href = sqlalchemy.Column(sqlalchemy.Text)
-    ref_id = sqlalchemy.Column(sqlalchemy.Text, nullable=True)
-    title = sqlalchemy.Column(sqlalchemy.Text, nullable=True)
-    ref_type = sqlalchemy.Column(sqlalchemy.Text)
-    update_record_id = sqlalchemy.Column(
+    href = mapped_column(sqlalchemy.Text)
+    ref_id = mapped_column(sqlalchemy.Text, nullable=True)
+    title = mapped_column(sqlalchemy.Text, nullable=True)
+    ref_type = mapped_column(sqlalchemy.Text)
+    update_record_id = mapped_column(
         UUID(as_uuid=True),
         sqlalchemy.ForeignKey(UpdateRecord.content_ptr_id),
         nullable=False,
@@ -111,23 +111,23 @@ class UpdateReference(PulpBase):
 class CoreRepository(PulpBase):
     __tablename__ = "core_repository"
 
-    pulp_id = sqlalchemy.Column(
+    pulp_id = mapped_column(
         UUID(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
     )
-    pulp_created = sqlalchemy.Column(sqlalchemy.DATETIME, default=datetime.now)
-    pulp_last_updated = sqlalchemy.Column(
+    pulp_created = mapped_column(sqlalchemy.DATETIME, default=datetime.now)
+    pulp_last_updated = mapped_column(
         sqlalchemy.DATETIME,
         default=datetime.now,
     )
-    name = sqlalchemy.Column(sqlalchemy.Text)
-    description = sqlalchemy.Column(sqlalchemy.Text, nullable=True)
-    next_version = sqlalchemy.Column(sqlalchemy.Integer)
-    pulp_type = sqlalchemy.Column(sqlalchemy.Text)
-    remote_id = sqlalchemy.Column(UUID(as_uuid=True), nullable=True)
-    retain_repo_versions = sqlalchemy.Column(sqlalchemy.Integer, nullable=True)
-    user_hidden = sqlalchemy.Column(sqlalchemy.Boolean)
+    name = mapped_column(sqlalchemy.Text)
+    description = mapped_column(sqlalchemy.Text, nullable=True)
+    next_version = mapped_column(sqlalchemy.Integer)
+    pulp_type = mapped_column(sqlalchemy.Text)
+    remote_id = mapped_column(UUID(as_uuid=True), nullable=True)
+    retain_repo_versions = mapped_column(sqlalchemy.Integer, nullable=True)
+    user_hidden = mapped_column(sqlalchemy.Boolean)
 
     repository_content = relationship(
         "CoreRepositoryContent",
@@ -142,24 +142,24 @@ class CoreRepository(PulpBase):
 class CoreRepositoryVersion(PulpBase):
     __tablename__ = "core_repositoryversion"
 
-    pulp_id = sqlalchemy.Column(
+    pulp_id = mapped_column(
         UUID(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
     )
-    pulp_created = sqlalchemy.Column(sqlalchemy.DATETIME, default=datetime.now)
-    pulp_last_updated = sqlalchemy.Column(
+    pulp_created = mapped_column(sqlalchemy.DATETIME, default=datetime.now)
+    pulp_last_updated = mapped_column(
         sqlalchemy.DATETIME,
         default=datetime.now,
     )
-    number = sqlalchemy.Column(sqlalchemy.Integer)
-    complete = sqlalchemy.Column(sqlalchemy.Boolean)
-    base_version_id = sqlalchemy.Column(UUID(as_uuid=True), nullable=True)
-    repository_id = sqlalchemy.Column(
+    number = mapped_column(sqlalchemy.Integer)
+    complete = mapped_column(sqlalchemy.Boolean)
+    base_version_id = mapped_column(UUID(as_uuid=True), nullable=True)
+    repository_id = mapped_column(
         UUID(as_uuid=True),
         sqlalchemy.ForeignKey(CoreRepository.pulp_id),
     )
-    info = sqlalchemy.Column(JSONB)
+    info = mapped_column(JSONB)
 
     repository = relationship(
         CoreRepository,
@@ -170,22 +170,22 @@ class CoreRepositoryVersion(PulpBase):
 class CoreContent(PulpBase):
     __tablename__ = "core_content"
 
-    pulp_id = sqlalchemy.Column(
+    pulp_id = mapped_column(
         UUID(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
     )
-    pulp_created = sqlalchemy.Column(sqlalchemy.DATETIME, default=datetime.now)
-    pulp_last_updated = sqlalchemy.Column(
+    pulp_created = mapped_column(sqlalchemy.DATETIME, default=datetime.now)
+    pulp_last_updated = mapped_column(
         sqlalchemy.DATETIME,
         default=datetime.now,
     )
-    pulp_type = sqlalchemy.Column(sqlalchemy.Text)
-    upstream_id = sqlalchemy.Column(
+    pulp_type = mapped_column(sqlalchemy.Text)
+    upstream_id = mapped_column(
         UUID(as_uuid=True),
         nullable=True,
     )
-    timestamp_of_interest = sqlalchemy.Column(
+    timestamp_of_interest = mapped_column(
         sqlalchemy.DATETIME,
         default=datetime.now,
     )
@@ -210,24 +210,24 @@ class CoreContent(PulpBase):
 class CoreContentArtifact(PulpBase):
     __tablename__ = "core_contentartifact"
 
-    pulp_id = sqlalchemy.Column(
+    pulp_id = mapped_column(
         UUID(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
     )
-    pulp_created = sqlalchemy.Column(sqlalchemy.DATETIME, default=datetime.now)
-    pulp_last_updated = sqlalchemy.Column(
+    pulp_created = mapped_column(sqlalchemy.DATETIME, default=datetime.now)
+    pulp_last_updated = mapped_column(
         sqlalchemy.DATETIME,
         default=datetime.now,
         nullable=True,
     )
-    relative_path = sqlalchemy.Column(sqlalchemy.Text)
-    artifact_id = sqlalchemy.Column(
+    relative_path = mapped_column(sqlalchemy.Text)
+    artifact_id = mapped_column(
         UUID(as_uuid=True),
         sqlalchemy.ForeignKey("core_artifact.pulp_id"),
         nullable=True,
     )
-    content_id = sqlalchemy.Column(
+    content_id = mapped_column(
         UUID(as_uuid=True),
         sqlalchemy.ForeignKey(CoreContent.pulp_id),
     )
@@ -246,26 +246,26 @@ class CoreContentArtifact(PulpBase):
 class CoreArtifact(PulpBase):
     __tablename__ = "core_artifact"
 
-    pulp_id = sqlalchemy.Column(
+    pulp_id = mapped_column(
         UUID(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
     )
-    pulp_created = sqlalchemy.Column(sqlalchemy.DATETIME, default=datetime.now)
-    pulp_last_updated = sqlalchemy.Column(
+    pulp_created = mapped_column(sqlalchemy.DATETIME, default=datetime.now)
+    pulp_last_updated = mapped_column(
         sqlalchemy.DATETIME,
         default=datetime.now,
         nullable=True,
     )
-    file = sqlalchemy.Column(sqlalchemy.VARCHAR(255))
-    size = sqlalchemy.Column(sqlalchemy.BigInteger)
-    md5 = sqlalchemy.Column(sqlalchemy.VARCHAR(32), nullable=True)
-    sha1 = sqlalchemy.Column(sqlalchemy.VARCHAR(40), nullable=True)
-    sha224 = sqlalchemy.Column(sqlalchemy.VARCHAR(56), nullable=True)
-    sha256 = sqlalchemy.Column(sqlalchemy.VARCHAR(64))
-    sha384 = sqlalchemy.Column(sqlalchemy.VARCHAR(96), nullable=True)
-    sha512 = sqlalchemy.Column(sqlalchemy.VARCHAR(128), nullable=True)
-    timestamp_of_interest = sqlalchemy.Column(
+    file = mapped_column(sqlalchemy.VARCHAR(255))
+    size = mapped_column(sqlalchemy.BigInteger)
+    md5 = mapped_column(sqlalchemy.VARCHAR(32), nullable=True)
+    sha1 = mapped_column(sqlalchemy.VARCHAR(40), nullable=True)
+    sha224 = mapped_column(sqlalchemy.VARCHAR(56), nullable=True)
+    sha256 = mapped_column(sqlalchemy.VARCHAR(64))
+    sha384 = mapped_column(sqlalchemy.VARCHAR(96), nullable=True)
+    sha512 = mapped_column(sqlalchemy.VARCHAR(128), nullable=True)
+    timestamp_of_interest = mapped_column(
         sqlalchemy.DATETIME,
         default=datetime.now,
     )
@@ -278,29 +278,29 @@ class CoreArtifact(PulpBase):
 class CoreRepositoryContent(PulpBase):
     __tablename__ = "core_repositorycontent"
 
-    pulp_id = sqlalchemy.Column(
+    pulp_id = mapped_column(
         UUID(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
     )
-    pulp_created = sqlalchemy.Column(sqlalchemy.DATETIME, default=datetime.now)
-    pulp_last_updated = sqlalchemy.Column(
+    pulp_created = mapped_column(sqlalchemy.DATETIME, default=datetime.now)
+    pulp_last_updated = mapped_column(
         sqlalchemy.DATETIME,
         default=datetime.now,
     )
-    content_id = sqlalchemy.Column(
+    content_id = mapped_column(
         UUID(as_uuid=True),
         sqlalchemy.ForeignKey(CoreContent.pulp_id),
     )
-    repository_id = sqlalchemy.Column(
+    repository_id = mapped_column(
         UUID(as_uuid=True),
         sqlalchemy.ForeignKey(CoreRepository.pulp_id),
     )
-    version_added_id = sqlalchemy.Column(
+    version_added_id = mapped_column(
         UUID(as_uuid=True),
         sqlalchemy.ForeignKey(CoreRepositoryVersion.pulp_id),
     )
-    version_removed_id = sqlalchemy.Column(
+    version_removed_id = mapped_column(
         UUID(as_uuid=True),
         sqlalchemy.ForeignKey(CoreRepositoryVersion.pulp_id),
         nullable=True,
@@ -329,47 +329,47 @@ class CoreRepositoryContent(PulpBase):
 class RpmPackage(PulpBase):
     __tablename__ = "rpm_package"
 
-    content_ptr_id = sqlalchemy.Column(
+    content_ptr_id = mapped_column(
         UUID(as_uuid=True),
         sqlalchemy.ForeignKey(CoreContent.pulp_id),
         primary_key=True,
     )
-    name = sqlalchemy.Column(sqlalchemy.VARCHAR(255))
-    epoch = sqlalchemy.Column(sqlalchemy.VARCHAR(10))
-    version = sqlalchemy.Column(sqlalchemy.VARCHAR(255))
-    release = sqlalchemy.Column(sqlalchemy.VARCHAR(255))
-    arch = sqlalchemy.Column(sqlalchemy.VARCHAR(20))
-    pkgId = sqlalchemy.Column(sqlalchemy.Text)
-    checksum_type = sqlalchemy.Column(sqlalchemy.Text)
-    summary = sqlalchemy.Column(sqlalchemy.Text)
-    description = sqlalchemy.Column(sqlalchemy.Text)
-    url = sqlalchemy.Column(sqlalchemy.Text)
-    # changelogs = sqlalchemy.Column(JSONB)
-    # files = sqlalchemy.Column(JSONB)
-    # requires = sqlalchemy.Column(JSONB)
-    # provides = sqlalchemy.Column(JSONB)
-    # conflicts = sqlalchemy.Column(JSONB)
-    # obsoletes = sqlalchemy.Column(JSONB)
-    # suggests = sqlalchemy.Column(JSONB)
-    # enhances = sqlalchemy.Column(JSONB)
-    # recommends = sqlalchemy.Column(JSONB)
-    # supplements = sqlalchemy.Column(JSONB)
-    location_base = sqlalchemy.Column(sqlalchemy.Text)
-    location_href = sqlalchemy.Column(sqlalchemy.Text)
-    rpm_buildhost = sqlalchemy.Column(sqlalchemy.Text)
-    rpm_group = sqlalchemy.Column(sqlalchemy.Text)
-    rpm_license = sqlalchemy.Column(sqlalchemy.Text)
-    rpm_packager = sqlalchemy.Column(sqlalchemy.Text)
-    rpm_sourcerpm = sqlalchemy.Column(sqlalchemy.Text)
-    rpm_vendor = sqlalchemy.Column(sqlalchemy.Text)
-    rpm_header_start = sqlalchemy.Column(sqlalchemy.BigInteger, nullable=True)
-    rpm_header_end = sqlalchemy.Column(sqlalchemy.BigInteger, nullable=True)
-    is_modular = sqlalchemy.Column(sqlalchemy.Boolean)
-    size_archive = sqlalchemy.Column(sqlalchemy.BigInteger, nullable=True)
-    size_installed = sqlalchemy.Column(sqlalchemy.BigInteger, nullable=True)
-    size_package = sqlalchemy.Column(sqlalchemy.BigInteger, nullable=True)
-    time_build = sqlalchemy.Column(sqlalchemy.BigInteger, nullable=True)
-    time_file = sqlalchemy.Column(sqlalchemy.BigInteger, nullable=True)
+    name = mapped_column(sqlalchemy.VARCHAR(255))
+    epoch = mapped_column(sqlalchemy.VARCHAR(10))
+    version = mapped_column(sqlalchemy.VARCHAR(255))
+    release = mapped_column(sqlalchemy.VARCHAR(255))
+    arch = mapped_column(sqlalchemy.VARCHAR(20))
+    pkgId = mapped_column(sqlalchemy.Text)
+    checksum_type = mapped_column(sqlalchemy.Text)
+    summary = mapped_column(sqlalchemy.Text)
+    description = mapped_column(sqlalchemy.Text)
+    url = mapped_column(sqlalchemy.Text)
+    # changelogs = mapped_column(JSONB)
+    # files = mapped_column(JSONB)
+    # requires = mapped_column(JSONB)
+    # provides = mapped_column(JSONB)
+    # conflicts = mapped_column(JSONB)
+    # obsoletes = mapped_column(JSONB)
+    # suggests = mapped_column(JSONB)
+    # enhances = mapped_column(JSONB)
+    # recommends = mapped_column(JSONB)
+    # supplements = mapped_column(JSONB)
+    location_base = mapped_column(sqlalchemy.Text)
+    location_href = mapped_column(sqlalchemy.Text)
+    rpm_buildhost = mapped_column(sqlalchemy.Text)
+    rpm_group = mapped_column(sqlalchemy.Text)
+    rpm_license = mapped_column(sqlalchemy.Text)
+    rpm_packager = mapped_column(sqlalchemy.Text)
+    rpm_sourcerpm = mapped_column(sqlalchemy.Text)
+    rpm_vendor = mapped_column(sqlalchemy.Text)
+    rpm_header_start = mapped_column(sqlalchemy.BigInteger, nullable=True)
+    rpm_header_end = mapped_column(sqlalchemy.BigInteger, nullable=True)
+    is_modular = mapped_column(sqlalchemy.Boolean)
+    size_archive = mapped_column(sqlalchemy.BigInteger, nullable=True)
+    size_installed = mapped_column(sqlalchemy.BigInteger, nullable=True)
+    size_package = mapped_column(sqlalchemy.BigInteger, nullable=True)
+    time_build = mapped_column(sqlalchemy.BigInteger, nullable=True)
+    time_file = mapped_column(sqlalchemy.BigInteger, nullable=True)
 
     content: CoreContent = relationship(
         CoreContent,
@@ -412,16 +412,16 @@ class RpmPackage(PulpBase):
 class RpmModulemd(PulpBase):
     __tablename__ = "rpm_modulemd"
 
-    content_ptr_id = sqlalchemy.Column(
+    content_ptr_id = mapped_column(
         UUID(as_uuid=True),
         sqlalchemy.ForeignKey(CoreContent.pulp_id),
         primary_key=True,
     )
-    name = sqlalchemy.Column(sqlalchemy.Text)
-    stream = sqlalchemy.Column(sqlalchemy.Text)
-    version = sqlalchemy.Column(sqlalchemy.Text)
-    context = sqlalchemy.Column(sqlalchemy.Text)
-    arch = sqlalchemy.Column(sqlalchemy.Text)
+    name = mapped_column(sqlalchemy.Text)
+    stream = mapped_column(sqlalchemy.Text)
+    version = mapped_column(sqlalchemy.Text)
+    context = mapped_column(sqlalchemy.Text)
+    arch = mapped_column(sqlalchemy.Text)
 
     @property
     def nsvca(self):
@@ -431,12 +431,12 @@ class RpmModulemd(PulpBase):
 class RpmModulemdPackages(PulpBase):
     __tablename__ = "rpm_modulemd_packages"
 
-    id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
-    modulemd_id = sqlalchemy.Column(
+    id = mapped_column(sqlalchemy.Integer, primary_key=True)
+    modulemd_id = mapped_column(
         UUID(as_uuid=True),
         sqlalchemy.ForeignKey(RpmModulemd.content_ptr_id),
     )
-    package_id = sqlalchemy.Column(
+    package_id = mapped_column(
         UUID(as_uuid=True),
         sqlalchemy.ForeignKey(RpmPackage.content_ptr_id),
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
 fastapi==0.110.0
 fastapi-users[all]==12.1.3
 # Can be updated only after migration to SQLAlchemy > 2.0
-fastapi-users-db-sqlalchemy==4.0.5
+fastapi-users-db-sqlalchemy==6.0.1
 uvicorn==0.27.1
 asyncpg==0.29.0
 psycopg2-binary==2.9.9
 pydantic==2.6.3
 pydantic-settings==2.2.1
-SQLAlchemy==1.4.51
+SQLAlchemy==2.0.28
 aiohttp==3.9.3
 aiohttp-retry==2.8.3
 aiofiles==23.2.1


### PR DESCRIPTION
Resolves: https://github.com/AlmaLinux/build-system/issues/203

What has been done:
- Configured `fastapi-users-db-sqlalchemy` and `SQLAlchemy` to the latest versions (6.0.1 and 2.0.27 respectively) in `requirements.txt`
- Added `DeclarativeBase` and `MetaData` (for `Base`) in `database.py` to replace `declarative_base()` for `Base` and `PulpBase`
- AsyncAttrs
- [Replaced](https://docs.sqlalchemy.org/en/20/changelog/whatsnew_20.html#step-two-replace-declarative-use-of-schema-column-with-orm-mapped-column) declarative use of `Column` with `mapped_column()` in `models.py` and `pulp_models.py`
- Type hints for tables in `models.py` and `pulp_models.py`