### PR TITLE
Switch CS9 flavor to use koji repos directly and add CS10 flavor

### DIFF
--- a/reference_data/platform_flavors.yaml
+++ b/reference_data/platform_flavors.yaml
@@ -483,89 +483,78 @@
       debug: false
       priority: 10
 
-- name: CenotOS-9-Stream
+- name: CentOS-9-Stream
   repositories:
-    - name: baseos-cs9
+    - name: c9s-build
       arch: x86_64
       type: rpm
-      url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/
+      url: https://kojihub.stream.centos.org/kojifiles/repos/c9s-build/latest/x86_64/
       production: true
       debug: false
       priority: 11
-    - name: baseos-cs9
+    - name: c9s-build
       arch: aarch64
       type: rpm
-      url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/
+      url: https://kojihub.stream.centos.org/kojifiles/repos/c9s-build/latest/aarch64/
       production: true
       debug: false
       priority: 11
-    - name: baseos-cs9
+    - name: c9s-build
       arch: ppc64le
       type: rpm
-      url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/
+      url: https://kojihub.stream.centos.org/kojifiles/repos/c9s-build/latest/ppc64le/
       production: true
       debug: false
       priority: 11
-    - name: baseos-cs9
+    - name: c9s-build
       arch: s390x
       type: rpm
-      url: https://mirror.stream.centos.org/9-stream/BaseOS/s390x/os/
+      url: https://kojihub.stream.centos.org/kojifiles/repos/c9s-build/latest/s390x/
       production: true
       debug: false
       priority: 11
-    - name: appstream-cs9
+    - name: c9s-build
+      arch: i686
+      type: rpm
+      url: https://kojihub.stream.centos.org/kojifiles/repos/c9s-build/latest/i386/
+      production: true
+      debug: false
+      priority: 11
+
+- name: CentOS-10-Stream
+  repositories:
+    - name: c10s-build
       arch: x86_64
       type: rpm
-      url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/
+      url: https://kojihub.stream.centos.org/kojifiles/repos/c10s-build/latest/x86_64/
       production: true
       debug: false
       priority: 11
-    - name: appstream-cs9
+    - name: c10s-build
       arch: aarch64
       type: rpm
-      url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/
+      url: https://kojihub.stream.centos.org/kojifiles/repos/c10s-build/latest/aarch64/
       production: true
       debug: false
       priority: 11
-    - name: appstream-cs9
+    - name: c10s-build
       arch: ppc64le
       type: rpm
-      url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/
+      url: https://kojihub.stream.centos.org/kojifiles/repos/c10s-build/latest/ppc64le/
       production: true
       debug: false
       priority: 11
-    - name: appstream-cs9
+    - name: c10s-build
       arch: s390x
       type: rpm
-      url: https://mirror.stream.centos.org/9-stream/AppStream/s390x/os/
+      url: https://kojihub.stream.centos.org/kojifiles/repos/c10s-build/latest/s390x/
       production: true
       debug: false
       priority: 11
-    - name: crb-cs9
-      arch: x86_64
+    - name: c10s-build
+      arch: i686
       type: rpm
-      url: https://mirror.stream.centos.org/9-stream/CRB/x86_64/os/
-      production: true
-      debug: false
-      priority: 11
-    - name: crb-cs9
-      arch: aarch64
-      type: rpm
-      url: https://mirror.stream.centos.org/9-stream/CRB/aarch64/os/
-      production: true
-      debug: false
-      priority: 11
-    - name: crb-cs9
-      arch: ppc64le
-      type: rpm
-      url: https://mirror.stream.centos.org/9-stream/CRB/ppc64le/os/
-      production: true
-      debug: false
-      priority: 11
-    - name: crb-cs9
-      arch: s390x
-      type: rpm
-      url: https://mirror.stream.centos.org/9-stream/CRB/s390x/os/
+      url: https://kojihub.stream.centos.org/kojifiles/repos/c10s-build/latest/i386/
       production: true
       debug: false
       priority: 11


### PR DESCRIPTION
This PR does the following:
1. Switch CS9 flavor to use koji repos directly: https://kojihub.stream.centos.org/kojifiles/repos/c9s-build/latest/
2. Fix typo in CS9 flavor name
3. Add CS10 flavor with koji repos: https://kojihub.stream.centos.org/kojifiles/repos/c10s-build/latest/