### PR TITLE
Use the frontend image with preinstalled node_modules

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -301,16 +301,15 @@ services:
         max-file: "3"
 
   frontend:
-    image: quay.io/almalinuxorg/albs-frontend:latest
+    image: albs-frontend:latest
     env_file:
       - vars.env
     build:
       dockerfile: Dockerfile
       context: ../albs-frontend
-    command: bash -c "npm install && npm run dev"
+    command: npm run dev
     volumes:
       - "../albs-frontend:/home/albs/code"
-      - "frontend_node_modules:/code/node_modules"
     restart: on-failure
     depends_on:
       - web_server
@@ -550,5 +549,4 @@ services:
         max-file: "3"
 
 volumes:
-  frontend_node_modules:
   redis:


### PR DESCRIPTION
There's no need now to use the `frontend_node_modules` volume and run `npm install` before any other `npm` command.

Resolves: AlmaLinux/build-system/issues/223