### PR TITLE
Fix MissingGreenlet in getting new test tasks

### DIFF
--- a/alws/crud/test.py
+++ b/alws/crud/test.py
@@ -81,7 +81,8 @@ async def get_available_test_tasks(session: AsyncSession) -> List[dict]:
             ),
             selectinload(models.TestTask.build_task)
             .selectinload(models.BuildTask.build)
-            .selectinload(models.Build.linked_builds),
+            .selectinload(models.Build.linked_builds)
+            .selectinload(models.Build.repos),
             selectinload(models.TestTask.build_task)
             .selectinload(models.BuildTask.build)
             .selectinload(models.Build.platform_flavors)


### PR DESCRIPTION
The issue with linked builds is that we didn't ask for linked builds' build repositories, thus when we tried process the build with linked builds we would fail each time.