### PR TITLE
Provisioning data missing from albs-deploy

### DIFF
--- a/alws/crud/repository.py
+++ b/alws/crud/repository.py
@@ -169,6 +169,8 @@ async def add_to_platform(
     new_repos_list = list(set(repositories + platform.repos))
 
     platform.repos = new_repos_list
+    for repo in new_repos_list:
+        repo.platform_id = platform_id
     db.add(platform)
     db.add_all(new_repos_list)
     await db.flush()

--- a/alws/routers/sign_key.py
+++ b/alws/routers/sign_key.py
@@ -38,8 +38,10 @@ async def get_sign_keys(
 async def create_sign_key(
     payload: sign_schema.SignKeyCreate,
     db: AsyncSession = Depends(AsyncSessionDependency(key=get_async_db_key())),
+    user=Depends(get_current_user),
 ):
     try:
+        payload.owner_id = user.id
         return await sign_key.create_sign_key(db, payload)
     except (PlatformMissingError, SignKeyAlreadyExistsError) as e:
         raise HTTPException(status.HTTP_400_BAD_REQUEST, str(e))

--- a/alws/schemas/repository_schema.py
+++ b/alws/schemas/repository_schema.py
@@ -36,6 +36,7 @@ class RepositoryCreate(BaseModel):
     priority: int = 10
     production: bool = False
     mock_enabled: bool = True
+    owner_id: typing.Optional[int] = None
     export_path: typing.Optional[str] = None
     pulp_href: typing.Optional[str] = None
 

--- a/alws/schemas/sign_schema.py
+++ b/alws/schemas/sign_schema.py
@@ -25,6 +25,7 @@ class SignKeyCreate(BaseModel):
     fingerprint: str
     public_url: str
     platform_id: typing.Optional[int] = None
+    owner_id: typing.Optional[int] = None
 
 
 class SignKeyUpdate(BaseModel):


### PR DESCRIPTION
Provisioning data missing from albs-deploy

- writing owner_id to platforms, repositories and sign keys
- writing platform_id to repositories
- added test for platforms/{id}/add-repositories/ endpoint

Resolves: AlmaLinux/build-system#235