### PR TITLE
Fix nginx service dependencies

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -501,6 +501,7 @@ services:
     depends_on:
       - web_server
       - frontend
+      - sign_file
     logging:
       driver: "json-file"
       options:


### PR DESCRIPTION
Default nginx config (_nginx_configs/albs.conf_) requires sign_file service to be running.

Error log when sign_file service is not running:
```
nginx-1  | nginx: [emerg] host not found in upstream "sign_file:8000" in /etc/nginx/conf.d/albs.conf:14
nginx-1 exited with code 1
```