### PR TITLE
Fix EPEL URL

### DIFF
--- a/reference_data/platform_flavors.yaml
+++ b/reference_data/platform_flavors.yaml
@@ -189,28 +189,28 @@
     - name: epel
       arch: x86_64
       type: rpm
-      url: https://download.fedoraproject.org/pub/epel/$releasever/Everything/x86_64/
+      url: https://dl.fedoraproject.org/pub/epel/$releasever/Everything/x86_64/
       production: false
       debug: false
       priority: 10
     - name: epel
       arch: aarch64
       type: rpm
-      url: https://download.fedoraproject.org/pub/epel/$releasever/Everything/aarch64/
+      url: https://dl.fedoraproject.org/pub/epel/$releasever/Everything/aarch64/
       production: false
       debug: false
       priority: 10
     - name: epel
       arch: ppc64le
       type: rpm
-      url: https://download.fedoraproject.org/pub/epel/$releasever/Everything/ppc64le/
+      url: https://dl.fedoraproject.org/pub/epel/$releasever/Everything/ppc64le/
       production: false
       debug: false
       priority: 10
     - name: epel
       arch: s390x
       type: rpm
-      url: https://download.fedoraproject.org/pub/epel/$releasever/Everything/s390x/
+      url: https://dl.fedoraproject.org/pub/epel/$releasever/Everything/s390x/
       production: false
       debug: false
       priority: 10
@@ -220,14 +220,14 @@
     - name: epel
       arch: x86_64
       type: rpm
-      url: https://download.fedoraproject.org/pub/epel/$releasever/x86_64/
+      url: https://dl.fedoraproject.org/pub/epel/$releasever/x86_64/
       production: false
       debug: false
       priority: 10
     - name: epel
       arch: aarch64
       type: rpm
-      url: https://download.fedoraproject.org/pub/epel/$releasever/aarch64/
+      url: https://dl.fedoraproject.org/pub/epel/$releasever/aarch64/
       production: false
       debug: false
       priority: 10


### PR DESCRIPTION
Currently ALBS has issues with accessing https://download.fedoraproject.org so switched to another address.