### PR TITLE
Expose proxy config for pulp

### DIFF
--- a/alws/crud/repository.py
+++ b/alws/crud/repository.py
@@ -229,12 +229,18 @@ async def create_repository_remote(
             remote_href,
             payload.url,
             remote_policy=payload.policy,
+            proxy_url=payload.proxy_url,
+            proxy_username=payload.proxy_username,
+            proxy_password=payload.proxy_password,
         )
     else:
         remote_href = await pulp_client.create_rpm_remote(
             payload.name,
             payload.url,
             remote_policy=payload.policy,
+            proxy_url=payload.proxy_url,
+            proxy_username=payload.proxy_username,
+            proxy_password=payload.proxy_password,
         )
     if remote:
         return remote

--- a/alws/schemas/remote_schema.py
+++ b/alws/schemas/remote_schema.py
@@ -19,6 +19,9 @@ class RemoteCreate(BaseModel):
     arch: str
     url: str
     policy: str = 'on_demand'
+    proxy_url: typing.Optional[str] = None
+    proxy_username: typing.Optional[str] = None
+    proxy_password: typing.Optional[str] = None
 
 
 class RemoteUpdate(BaseModel):

--- a/alws/utils/gitea.py
+++ b/alws/utils/gitea.py
@@ -27,7 +27,7 @@ def modules_yaml_path_from_url(url: str, ref: str, ref_type: str) -> str:
 
 async def download_modules_yaml(url: str, ref: str, ref_type: str) -> str:
     template_path = modules_yaml_path_from_url(url, ref, ref_type)
-    async with aiohttp.ClientSession() as session:
+    async with aiohttp.ClientSession(trust_env=True) as session:
         async with session.get(template_path) as response:
             template = await response.text()
             try:
@@ -56,7 +56,7 @@ class GiteaClient:
                     f' {full_url}, with params: {params}'
                 )
                 async with self.requests_lock:
-                    async with aiohttp.ClientSession() as session:
+                    async with aiohttp.ClientSession(trust_env=True) as session:
                         async with session.get(
                             full_url, params=params
                         ) as response:

--- a/alws/utils/github.py
+++ b/alws/utils/github.py
@@ -13,7 +13,7 @@ async def get_user_github_token(
         'client_secret': client_secret
     }
     headers = {'accept': 'application/json'}
-    async with aiohttp.ClientSession() as session:
+    async with aiohttp.ClientSession(trust_env=True) as session:
         async with session.post(
                 client_secrets_endpoint,
                 json=payload,
@@ -25,7 +25,7 @@ async def get_user_github_token(
 async def get_github_user_info(token: str):
     user_endpoint = 'https://api.github.com/user'
     headers = {'authorization': f'token {token}'}
-    async with aiohttp.ClientSession() as session:
+    async with aiohttp.ClientSession(trust_env=True) as session:
         async with session.get(user_endpoint, headers=headers) as response:
             response.raise_for_status()
             response = await response.json()
@@ -40,7 +40,7 @@ async def get_github_user_info(token: str):
 async def get_github_user_emails(token: str):
     user_endpoint = 'https://api.github.com/user/emails'
     headers = {'authorization': f'token {token}'}
-    async with aiohttp.ClientSession() as session:
+    async with aiohttp.ClientSession(trust_env=True) as session:
         async with session.get(user_endpoint, headers=headers) as response:
             response.raise_for_status()
             return await response.json()
@@ -49,7 +49,7 @@ async def get_github_user_emails(token: str):
 async def get_github_user_organizations(token: str):
     org_endpoint = 'https://api.github.com/user/memberships/orgs'
     headers = {'authorization': f'token {token}'}
-    async with aiohttp.ClientSession() as session:
+    async with aiohttp.ClientSession(trust_env=True) as session:
         async with session.get(org_endpoint, headers=headers) as response:
             response.raise_for_status()
             return await response.json()

--- a/alws/utils/pulp_client.py
+++ b/alws/utils/pulp_client.py
@@ -760,6 +760,9 @@ class PulpClient:
         remote_name: str,
         remote_url: str,
         remote_policy: str = "on_demand",
+        proxy_url: typing.Optional[str] = None,
+        proxy_username: typing.Optional[str] = None,
+        proxy_password: typing.Optional[str] = None,
     ) -> str:
         """
         Policy variants: 'on_demand', 'immediate', 'streamed'
@@ -770,17 +773,29 @@ class PulpClient:
             "url": remote_url,
             "policy": remote_policy,
             "download_concurrency": 5,
+            "proxy_url": proxy_url,
+            "proxy_username": proxy_username,
+            "proxy_password": proxy_password,
         }
         result = await self.request("POST", endpoint, json=payload)
         return result["pulp_href"]
 
     async def update_rpm_remote(
-        self, remote_href, remote_url: str, remote_policy: str = "on_demand"
+        self,
+        remote_href: str,
+        remote_url: str,
+        remote_policy: str = "on_demand",
+        proxy_url: typing.Optional[str] = None,
+        proxy_username: typing.Optional[str] = None,
+        proxy_password: typing.Optional[str] = None,
     ) -> str:
         payload = {
             "url": remote_url,
             "policy": remote_policy,
             "download_concurrency": 5,
+            "proxy_url": proxy_url,
+            "proxy_username": proxy_username,
+            "proxy_password": proxy_password,
         }
 
         await self.request("PATCH", remote_href, data=payload)

--- a/scripts/bootstrap_repositories.py
+++ b/scripts/bootstrap_repositories.py
@@ -153,6 +153,9 @@ async def get_remote(repo_info: dict, remote_sync_policy: str):
         remote_payload.pop("production", False)
         remote_payload["url"] = remote_payload["remote_url"]
         remote_payload["policy"] = remote_sync_policy
+        remote_payload["proxy_url"] = os.getenv("PULP_PROXY_URL")
+        remote_payload["proxy_username"] = os.getenv("PULP_PROXY_USERNAME")
+        remote_payload["proxy_password"] = os.getenv("PULP_PROXY_PASSWORD")
         remote = await repo_crud.create_repository_remote(
             db, remote_schema.RemoteCreate(**remote_payload)
         )


### PR DESCRIPTION
Pulp does not respect environment variables like http_proxy for proxy
config, so it needs to be set directly.

This PR exposes three of the proxy related parameters as environment variables.
https://pulpproject.org/pulp_rpm/restapi/#tag/Remotes:-Rpm/operation/remotes_rpm_rpm_create

- PULP_PROXY_URL
- PULP_PROXY_USERNAME
- PULP_PROXY_PASSWORD

Also set trust_env=True to gitea session. aiohttp does not read proxy environment variables without this option.
https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.ClientSession.trust_env

Resolves: https://github.com/AlmaLinux/build-system/issues/312