### PR TITLE
Use COMPOSE_PROJECT_NAME as the network name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
       context: ../alts
     environment:
       CELERY_CONFIG_PATH: "/celery_config.yaml"
-      EXTERNAL_NETWORK: "albs-web-server_default"
+      EXTERNAL_NETWORK: "${COMPOSE_PROJECT_NAME:-albs-web-server}_default"
     command:
       celery -A alts.worker.app worker
         --pool=threads --concurrency=20


### PR DESCRIPTION
albs-deploy uses `-p albs` with docker compose so the project name is set to "albs" and the default network name is "albs_default", which is different from the current network name.
Use `$COMPOSE_PROJECT_NAME` to reference this dynamic project name.

Resolves: https://github.com/AlmaLinux/build-system/issues/317