### PR TITLE
Create endpoint to reset package mappings of unreleased erratas

### DIFF
--- a/alws/crud/errata.py
+++ b/alws/crud/errata.py
@@ -1715,3 +1715,66 @@ async def reset_matched_errata_packages(record_id: str, session: AsyncSession):
         items_to_insert.extend(matching_packages)
     session.add_all(items_to_insert)
     await session.flush()
+
+
+async def reset_matched_errata_packages_threshold(
+    issued_date_str: str, session: AsyncSession
+):
+    issued_date = datetime.datetime.strptime(
+        issued_date_str, '%Y-%m-%d %H:%M:%S'
+    )
+
+    stmt = (
+        select(models.NewErrataRecord)
+        .where(models.NewErrataRecord.issued_date >= issued_date)
+        .where(
+            models.NewErrataRecord.release_status
+            == ErrataReleaseStatus.NOT_RELEASED
+        )
+        .options(
+            selectinload(models.NewErrataRecord.platform).selectinload(
+                models.Platform.repos
+            ),
+            selectinload(models.NewErrataRecord.packages).selectinload(
+                models.NewErrataPackage.albs_packages
+            ),
+        )
+        .with_for_update()
+    )
+
+    result = await session.execute(stmt)
+    records = result.scalars().all()
+    print(records)
+    if not records:
+        return f"No unreleased records found after {issued_date_str} including"
+
+    for record in records:
+        items_to_insert = []
+        search_params = prepare_search_params(record)
+        prod_repos_cache = await load_platform_packages(
+            platform=record.platform,
+            search_params=search_params,
+            for_release=False,
+            module=record.module,
+        )
+        await session.execute(
+            delete(models.NewErrataToALBSPackage).where(
+                models.NewErrataToALBSPackage.errata_package_id.in_(
+                    (pkg.id for pkg in record.packages)
+                )
+            )
+        )
+        for package in record.packages:
+            matching_packages, _ = await get_matching_albs_packages(
+                session,
+                package,
+                prod_repos_cache,
+                record.module,
+            )
+            items_to_insert.extend(matching_packages)
+        session.add_all(items_to_insert)
+    await session.flush()
+    return (
+        f'Packages for records {[record.id for record in records]}'
+        f' have been matched if their date is later than {issued_date}'
+    )

--- a/alws/crud/errata.py
+++ b/alws/crud/errata.py
@@ -1668,6 +1668,31 @@ async def get_updateinfo_xml_from_pulp(
     return cr_upd.xml_dump() if cr_upd.updates else None
 
 
+async def prepare_resetting(items_to_insert: List, record: models.NewErrataRecord, session: AsyncSession):
+    search_params = prepare_search_params(record)
+    prod_repos_cache = await load_platform_packages(
+        platform=record.platform,
+        search_params=search_params,
+        for_release=False,
+        module=record.module,
+    )
+    await session.execute(
+        delete(models.NewErrataToALBSPackage).where(
+            models.NewErrataToALBSPackage.errata_package_id.in_(
+                (pkg.id for pkg in record.packages)
+            )
+        )
+    )
+    for package in record.packages:
+        matching_packages, _ = await get_matching_albs_packages(
+            session,
+            package,
+            prod_repos_cache,
+            record.module,
+        )
+        items_to_insert.extend(matching_packages)
+
+
 async def reset_matched_errata_packages(record_id: str, session: AsyncSession):
     record = (
         (
@@ -1691,28 +1716,7 @@ async def reset_matched_errata_packages(record_id: str, session: AsyncSession):
     if not record:
         return
     items_to_insert = []
-    search_params = prepare_search_params(record)
-    prod_repos_cache = await load_platform_packages(
-        platform=record.platform,
-        search_params=search_params,
-        for_release=False,
-        module=record.module,
-    )
-    await session.execute(
-        delete(models.NewErrataToALBSPackage).where(
-            models.NewErrataToALBSPackage.errata_package_id.in_(
-                (pkg.id for pkg in record.packages)
-            )
-        )
-    )
-    for package in record.packages:
-        matching_packages, _ = await get_matching_albs_packages(
-            session,
-            package,
-            prod_repos_cache,
-            record.module,
-        )
-        items_to_insert.extend(matching_packages)
+    await prepare_resetting(items_to_insert, record, session)
     session.add_all(items_to_insert)
     await session.flush()
 
@@ -1739,9 +1743,7 @@ async def get_errata_records_threshold(issued_date_str: str, session: AsyncSessi
         .with_for_update()
     )
 
-    result = await session.execute(stmt)
-    records = result.scalars().all()
-    await session.flush()
+    records = (await session.execute(stmt)).scalars().all()
     return records
 
 
@@ -1750,31 +1752,10 @@ async def reset_matched_erratas_packages_threshold(
 ):
     async with open_async_session(key=get_async_db_key()) as session:
         records = await get_errata_records_threshold(issued_date, session)
+        items_to_insert = []
         for record in records:
-            items_to_insert = []
-            search_params = prepare_search_params(record)
-            prod_repos_cache = await load_platform_packages(
-                platform=record.platform,
-                search_params=search_params,
-                for_release=False,
-                module=record.module,
-            )
-            await session.execute(
-                delete(models.NewErrataToALBSPackage).where(
-                    models.NewErrataToALBSPackage.errata_package_id.in_(
-                        (pkg.id for pkg in record.packages)
-                    )
-                )
-            )
-            for package in record.packages:
-                matching_packages, _ = await get_matching_albs_packages(
-                    session,
-                    package,
-                    prod_repos_cache,
-                    record.module,
-                )
-                items_to_insert.extend(matching_packages)
-            session.add_all(items_to_insert)
+            await prepare_resetting(items_to_insert, record, session)
+        session.add_all(items_to_insert)
         await session.flush()
     logging.info(f'Packages for records {[record.id for record in records]}'
                  f' have been matched if their date is later than {issued_date}')

--- a/alws/dramatiq/__init__.py
+++ b/alws/dramatiq/__init__.py
@@ -35,6 +35,6 @@ from alws.dramatiq.build import start_build, build_done
 from alws.dramatiq.products import perform_product_modification
 from alws.dramatiq.user import perform_user_removal
 from alws.dramatiq.releases import execute_release_plan, revert_release
-from alws.dramatiq.errata import bulk_errata_release, release_errata
+from alws.dramatiq.errata import bulk_errata_release, release_errata, reset_records_threshold
 from alws.dramatiq.sign_task import complete_sign_task
 from alws.dramatiq.tests import complete_test_task

--- a/alws/routers/errata.py
+++ b/alws/routers/errata.py
@@ -211,3 +211,16 @@ async def reset_matched_packages(
 ):
     await errata_crud.reset_matched_errata_packages(record_id, session)
     return {'message': f'Packages for record {record_id} have been matched'}
+
+
+@router.post('/reset-matched-packages-multiple')
+async def reset_matched_packages_multiple(
+    issued_date,
+    session: AsyncSession = Depends(
+        AsyncSessionDependency(key=get_async_db_key())
+    ),
+):
+    message = await errata_crud.reset_matched_errata_packages_threshold(
+        issued_date, session
+    )
+    return {'message': message}


### PR DESCRIPTION
Resolves: https://github.com/AlmaLinux/build-system/issues/308

Frontend: https://github.com/AlmaLinux/albs-frontend/pull/504 (**there is a need to discuss the frontend part**)
```
[2024-08-02 14:31:33,515] [PID 36] [Thread-5] [root] [INFO] Packages for records ['4'] have been matched if their date is later than 2024-07-27 16:29:00
2024-08-02 14:35:20 [info     ] engine startup                 engine=Engine(postgresql+psycopg2://postgres:***@pulp/pulp) engine_key=pulp
2024-08-02 14:35:20 [info     ] engine startup                 engine=Engine(postgresql+psycopg2://postgres:***@db/db) engine_key=default
2024-08-02 14:35:20 [info     ] engine startup                 async_engine=<sqlalchemy.ext.asyncio.engine.AsyncEngine object at 0x7faf86bcce00> engine_key=async
2024-08-02 14:35:20 [info     ] engine startup                 async_engine=<sqlalchemy.ext.asyncio.engine.AsyncEngine object at 0x7faf86bd5d80> engine_key=pulp_async
[2024-08-02 14:38:23,290] [PID 36] [Thread-5] [root] [INFO] Packages for records ['5', '4'] have been matched if their date is later than 2024-07-21 16:29:00
```
- added function to find erratas issued after a particular date and check if we have needed records in first place
- added a function to reset packages of these erratas
- added a dramatiq actor to schedule resetting as a background task