### PR TITLE
Add 'rpmautospec_enable' flag to AlmaLinux 10 platform

### DIFF
--- a/reference_data/platforms.yaml
+++ b/reference_data/platforms.yaml
@@ -3412,6 +3412,7 @@
       nspawn_args:
         - '--rlimit=RLIMIT_NOFILE=20480'
         - '--capability=cap_ipc_lock'
+      rpmautospec_enable: true
       secure_boot_macros:
         "%pe_signing_cert": 'f4217b7b99a69128'
         "%pe_signing_token": 'AlmaLinux OS Foundation'


### PR DESCRIPTION
Resolves: https://github.com/AlmaLinux/build-system/issues/324