### PR TITLE
Fix product creation

### DIFF
--- a/alws/crud/products.py
+++ b/alws/crud/products.py
@@ -142,7 +142,19 @@ async def create_product(
     db.add_all(items_to_insert)
     db.add(owner)
     await db.flush()
-    await db.refresh(product)
+    await db.refresh(
+        product,
+        attribute_names=[
+            'roles',
+            'repositories',
+            'platforms',
+            'builds',
+            'sign_keys',
+            'team',
+            'permissions',
+        ],
+    )
+    await db.refresh(product.team, attribute_names=['roles'])
     return product
 
 

--- a/alws/routers/products.py
+++ b/alws/routers/products.py
@@ -54,8 +54,6 @@ async def create_product(
     user: User = Depends(get_current_user),
 ):
     db_product = await products.create_product(db, product)
-    await db.flush()
-    await db.refresh(db_product)
     await sign_task.create_gen_key_task(
         db=db,
         product=db_product,

--- a/tests/test_api/test_products.py
+++ b/tests/test_api/test_products.py
@@ -53,19 +53,8 @@ class TestProductsEndpoints(BaseAsyncTestCase):
         # the test will be reported as failed.
         await _perform_product_modification(build_id, product_id, "add")
         await async_session.commit()
-        db_product = (
-            (
-                await async_session.execute(
-                    select(Product)
-                    .where(Product.id == product_id)
-                    .options(selectinload(Product.builds))
-                )
-            )
-            .scalars()
-            .first()
-        )
-
-        assert db_product.builds[0].id == build_id, message
+        await async_session.refresh(user_product, attribute_names=['builds'])
+        assert user_product.builds[0].id == build_id, message
 
     async def test_remove_from_product(
         self,


### PR DESCRIPTION
This commit resolves the following problem during product creation:
```
web_server-1  | Traceback (most recent call last):
web_server-1  |   File "/usr/local/lib/python3.9/site-packages/uvicorn/protocols/http/httptools_impl.py", line 401, in run_asgi
web_server-1  |     result = await app(  # type: ignore[func-returns-value]
web_server-1  |   File "/usr/local/lib/python3.9/site-packages/uvicorn/middleware/proxy_headers.py", line 70, in __call__
web_server-1  |     return await self.app(scope, receive, send)
web_server-1  |   File "/usr/local/lib/python3.9/site-packages/fastapi/applications.py", line 1054, in __call__
web_server-1  |     await super().__call__(scope, receive, send)
web_server-1  |   File "/usr/local/lib/python3.9/site-packages/sentry_sdk/integrations/starlette.py", line 374, in _sentry_patched_asgi_app
web_server-1  |     return await middleware(scope, receive, send)
web_server-1  |   File "/usr/local/lib/python3.9/site-packages/sentry_sdk/integrations/asgi.py", line 152, in _run_asgi3
web_server-1  |     return await self._run_app(scope, receive, send, asgi_version=3)
web_server-1  |   File "/usr/local/lib/python3.9/site-packages/sentry_sdk/integrations/asgi.py", line 246, in _run_app
web_server-1  |     raise exc from None
web_server-1  |   File "/usr/local/lib/python3.9/site-packages/sentry_sdk/integrations/asgi.py", line 241, in _run_app
web_server-1  |     return await self.app(
web_server-1  |   File "/usr/local/lib/python3.9/site-packages/starlette/applications.py", line 123, in __call__
web_server-1  |     await self.middleware_stack(scope, receive, send)
web_server-1  |   File "/usr/local/lib/python3.9/site-packages/sentry_sdk/integrations/starlette.py", line 169, in _create_span_call
web_server-1  |     return await old_call(app, scope, new_receive, new_send, **kwargs)
web_server-1  |   File "/usr/local/lib/python3.9/site-packages/starlette/middleware/errors.py", line 186, in __call__
web_server-1  |     raise exc
web_server-1  |   File "/usr/local/lib/python3.9/site-packages/starlette/middleware/errors.py", line 164, in __call__
web_server-1  |     await self.app(scope, receive, _send)
web_server-1  |   File "/usr/local/lib/python3.9/site-packages/sentry_sdk/integrations/starlette.py", line 169, in _create_span_call
web_server-1  |     return await old_call(app, scope, new_receive, new_send, **kwargs)
web_server-1  |   File "/usr/local/lib/python3.9/site-packages/fastapi_sqla/async_sqla.py", line 161, in __call__
web_server-1  |     await self.app(scope, receive, send_wrapper)
web_server-1  |   File "/usr/local/lib/python3.9/site-packages/sentry_sdk/integrations/starlette.py", line 169, in _create_span_call
web_server-1  |     return await old_call(app, scope, new_receive, new_send, **kwargs)
web_server-1  |   File "/usr/local/lib/python3.9/site-packages/fastapi_sqla/async_sqla.py", line 161, in __call__
web_server-1  |     await self.app(scope, receive, send_wrapper)
web_server-1  |   File "/usr/local/lib/python3.9/site-packages/sentry_sdk/integrations/starlette.py", line 169, in _create_span_call
web_server-1  |     return await old_call(app, scope, new_receive, new_send, **kwargs)
web_server-1  |   File "/usr/local/lib/python3.9/site-packages/fastapi_sqla/sqla.py", line 185, in __call__
web_server-1  |     await self.app(scope, receive, send_wrapper)
web_server-1  |   File "/usr/local/lib/python3.9/site-packages/sentry_sdk/integrations/starlette.py", line 169, in _create_span_call
web_server-1  |     return await old_call(app, scope, new_receive, new_send, **kwargs)
web_server-1  |   File "/usr/local/lib/python3.9/site-packages/fastapi_sqla/sqla.py", line 185, in __call__
web_server-1  |     await self.app(scope, receive, send_wrapper)
web_server-1  |   File "/usr/local/lib/python3.9/site-packages/sentry_sdk/integrations/starlette.py", line 268, in _sentry_exceptionmiddleware_call
web_server-1  |     await old_call(self, scope, receive, send)
web_server-1  |   File "/usr/local/lib/python3.9/site-packages/sentry_sdk/integrations/starlette.py", line 169, in _create_span_call
web_server-1  |     return await old_call(app, scope, new_receive, new_send, **kwargs)
web_server-1  |   File "/usr/local/lib/python3.9/site-packages/starlette/middleware/exceptions.py", line 65, in __call__
web_server-1  |     await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
web_server-1  |   File "/usr/local/lib/python3.9/site-packages/starlette/_exception_handler.py", line 64, in wrapped_app
web_server-1  |     raise exc
web_server-1  |   File "/usr/local/lib/python3.9/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
web_server-1  |     await app(scope, receive, sender)
web_server-1  |   File "/usr/local/lib/python3.9/site-packages/sentry_sdk/integrations/starlette.py", line 268, in _sentry_exceptionmiddleware_call
web_server-1  |     await old_call(self, scope, receive, send)
web_server-1  |   File "/usr/local/lib/python3.9/site-packages/sentry_sdk/integrations/starlette.py", line 169, in _create_span_call
web_server-1  |     return await old_call(app, scope, new_receive, new_send, **kwargs)
web_server-1  |   File "/usr/local/lib/python3.9/site-packages/starlette/middleware/exceptions.py", line 65, in __call__
web_server-1  |     await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
web_server-1  |   File "/usr/local/lib/python3.9/site-packages/starlette/_exception_handler.py", line 64, in wrapped_app
web_server-1  |     raise exc
web_server-1  |   File "/usr/local/lib/python3.9/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
web_server-1  |     await app(scope, receive, sender)
web_server-1  |   File "/usr/local/lib/python3.9/site-packages/starlette/routing.py", line 756, in __call__
web_server-1  |     await self.middleware_stack(scope, receive, send)
web_server-1  |   File "/usr/local/lib/python3.9/site-packages/starlette/routing.py", line 776, in app
web_server-1  |     await route.handle(scope, receive, send)
web_server-1  |   File "/usr/local/lib/python3.9/site-packages/starlette/routing.py", line 297, in handle
web_server-1  |     await self.app(scope, receive, send)
web_server-1  |   File "/usr/local/lib/python3.9/site-packages/starlette/routing.py", line 77, in app
web_server-1  |     await wrap_app_handling_exceptions(app, request)(scope, receive, send)
web_server-1  |   File "/usr/local/lib/python3.9/site-packages/starlette/_exception_handler.py", line 64, in wrapped_app
web_server-1  |     raise exc
web_server-1  |   File "/usr/local/lib/python3.9/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
web_server-1  |     await app(scope, receive, sender)
web_server-1  |   File "/usr/local/lib/python3.9/site-packages/starlette/routing.py", line 72, in app
web_server-1  |     response = await func(request)
web_server-1  |   File "/usr/local/lib/python3.9/site-packages/sentry_sdk/integrations/fastapi.py", line 137, in _sentry_app
web_server-1  |     return await old_app(*args, **kwargs)
web_server-1  |   File "/usr/local/lib/python3.9/site-packages/fastapi/routing.py", line 278, in app
web_server-1  |     raw_response = await run_endpoint_function(
web_server-1  |   File "/usr/local/lib/python3.9/site-packages/fastapi/routing.py", line 191, in run_endpoint_function
web_server-1  |     return await dependant.call(**values)
web_server-1  |   File "/code/alws/routers/products.py", line 57, in create_product
web_server-1  |     await sign_task.create_gen_key_task(
web_server-1  |   File "/code/alws/crud/sign_task.py", line 115, in create_gen_key_task
web_server-1  |     if not can_perform(product, user, actions.GenKey.name):
web_server-1  |   File "/code/alws/perms/authorization.py", line 27, in can_perform
web_server-1  |     obj_roles.extend(obj.team.roles)
web_server-1  |   File "/usr/local/lib64/python3.9/site-packages/sqlalchemy/orm/attributes.py", line 566, in __get__
web_server-1  |     return self.impl.get(state, dict_)  # type: ignore[no-any-return]
web_server-1  |   File "/usr/local/lib64/python3.9/site-packages/sqlalchemy/orm/attributes.py", line 1086, in get
web_server-1  |     value = self._fire_loader_callables(state, key, passive)
web_server-1  |   File "/usr/local/lib64/python3.9/site-packages/sqlalchemy/orm/attributes.py", line 1121, in _fire_loader_callables
web_server-1  |     return self.callable_(state, passive)
web_server-1  |   File "/usr/local/lib64/python3.9/site-packages/sqlalchemy/orm/strategies.py", line 967, in _load_for_state
web_server-1  |     return self._emit_lazyload(
web_server-1  |   File "/usr/local/lib64/python3.9/site-packages/sqlalchemy/orm/strategies.py", line 1130, in _emit_lazyload
web_server-1  |     result = session.execute(
web_server-1  |   File "/usr/local/lib64/python3.9/site-packages/sqlalchemy/orm/session.py", line 2362, in execute
web_server-1  |     return self._execute_internal(
web_server-1  |   File "/usr/local/lib64/python3.9/site-packages/sqlalchemy/orm/session.py", line 2247, in _execute_internal
web_server-1  |     result: Result[Any] = compile_state_cls.orm_execute_statement(
web_server-1  |   File "/usr/local/lib64/python3.9/site-packages/sqlalchemy/orm/context.py", line 293, in orm_execute_statement
web_server-1  |     result = conn.execute(
web_server-1  |   File "/usr/local/lib64/python3.9/site-packages/sqlalchemy/engine/base.py", line 1418, in execute
web_server-1  |     return meth(
web_server-1  |   File "/usr/local/lib64/python3.9/site-packages/sqlalchemy/sql/elements.py", line 515, in _execute_on_connection
web_server-1  |     return connection._execute_clauseelement(
web_server-1  |   File "/usr/local/lib64/python3.9/site-packages/sqlalchemy/engine/base.py", line 1640, in _execute_clauseelement
web_server-1  |     ret = self._execute_context(
web_server-1  |   File "/usr/local/lib64/python3.9/site-packages/sqlalchemy/engine/base.py", line 1846, in _execute_context
web_server-1  |     return self._exec_single_context(
web_server-1  |   File "/usr/local/lib64/python3.9/site-packages/sqlalchemy/engine/base.py", line 1986, in _exec_single_context
web_server-1  |     self._handle_dbapi_exception(
web_server-1  |   File "/usr/local/lib64/python3.9/site-packages/sqlalchemy/engine/base.py", line 2358, in _handle_dbapi_exception
web_server-1  |     raise exc_info[1].with_traceback(exc_info[2])
web_server-1  |   File "/usr/local/lib64/python3.9/site-packages/sqlalchemy/engine/base.py", line 1967, in _exec_single_context
web_server-1  |     self.dialect.do_execute(
web_server-1  |   File "/usr/local/lib64/python3.9/site-packages/sqlalchemy/engine/default.py", line 941, in do_execute
web_server-1  |     cursor.execute(statement, parameters)
web_server-1  |   File "/usr/local/lib64/python3.9/site-packages/sqlalchemy/dialects/postgresql/asyncpg.py", line 572, in execute
web_server-1  |     self._adapt_connection.await_(
web_server-1  |   File "/usr/local/lib64/python3.9/site-packages/sqlalchemy/util/_concurrency_py3k.py", line 123, in await_only
web_server-1  |     raise exc.MissingGreenlet(
web_server-1  | sqlalchemy.exc.MissingGreenlet: greenlet_spawn has not been called; can't call await_only() here. Was IO attempted in an unexpected place? (Background on this error at: https://sqlalche.me/e/20/xd2s)
```