### PR TITLE
Fix product deletion

### DIFF
--- a/alws/models.py
+++ b/alws/models.py
@@ -1071,6 +1071,11 @@ class Product(PermissionsMixin, TeamMixin, Base):
         back_populates="product",
         cascade="all, delete-orphan",
     )
+    gen_key_tasks: Mapped[List["GenKeyTask"]] = relationship(
+        "GenKeyTask",
+        back_populates="product",
+        cascade="all, delete-orphan",
+    )
 
     @property
     def full_name(self) -> str:

--- a/tests/fixtures/products.py
+++ b/tests/fixtures/products.py
@@ -6,11 +6,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from alws.crud.products import create_product
+from alws.crud.sign_task import create_gen_key_task
+from alws.crud.user import get_user
 from alws.models import Product, Repository
 from alws.schemas.product_schema import ProductCreate
-from alws.schemas.repository_schema import RepositoryCreate
 from tests.constants import ADMIN_USER_ID
-from tests.test_utils.pulp_utils import get_repo_href
 
 
 @pytest.fixture(
@@ -149,6 +149,11 @@ async def user_product(
         product = await create_product(
             async_session,
             ProductCreate(**user_product_create_payload),
+        )
+        await create_gen_key_task(
+            async_session,
+            product,
+            await get_user(async_session, user_id=user_product_create_payload['owner_id']),
         )
         await async_session.commit()
     yield product


### PR DESCRIPTION
This commit resolves the following problem during product deletion:
```
(sqlalchemy.dialects.postgresql.asyncpg.IntegrityError) <class 'asyncpg.exceptions.ForeignKeyViolationError'>: update or delete on table \"products\" violates foreign key constraint \"gen_key_tasks_product_id_fkey\" on table \"gen_key_tasks\"\nDETAIL:  Key (id)=(2) is still referenced from table \"gen_key_tasks\".\n[SQL: DELETE FROM products WHERE products.id = $1::INTEGER]\n[parameters: (2,)]\n(Background on this error at: https://sqlalche.me/e/20/gkpj)
```