### PR TITLE
- Remove the libsolv build from platfrom repositories

### DIFF
--- a/reference_data/platform_flavors.yaml
+++ b/reference_data/platform_flavors.yaml
@@ -873,3 +873,13 @@
       production: false
       debug: false
       priority: 20
+
+- name: libsolv_for_v2
+  repositories:
+    - name: libsolv_for_v2
+      arch: x86_64_v2
+      type: rpm
+      url: https://build.almalinux.org/pulp/content/copr/eabdullin1-libsolv_for_v2-almalinux-10-x86_64_v2-dr/
+      production: true
+      debug: false
+      priority: 9

--- a/reference_data/platforms.yaml
+++ b/reference_data/platforms.yaml
@@ -5308,13 +5308,6 @@
       production: false
       debug: false
       priority: 10
-    - name: almalinux-10-libsolv
-      arch: x86_64_v2
-      type: rpm
-      remote_url: https://build.almalinux.org/pulp/content/builds/AlmaLinux-10-x86_64_v2-15762-br/
-      production: false
-      debug: false
-      priority: 10
 
 - name: AlmaLinux-Kitten-10
   distr_type: rhel


### PR DESCRIPTION
- Add a flavor that contains patched libsolv for x86_64_v2