### PR TITLE
Set EPEL-10 flavor repositories' names to 'epel-10'

### DIFF
--- a/reference_data/platform_flavors.yaml
+++ b/reference_data/platform_flavors.yaml
@@ -234,28 +234,28 @@
 
 - name: EPEL-10
   repositories:
-    - name: epel
+    - name: epel-10
       arch: x86_64
       type: rpm
       url: https://dl.fedoraproject.org/pub/epel/$releasever/Everything/x86_64/os/
       production: false
       debug: false
       priority: 10
-    - name: epel
+    - name: epel-10
       arch: aarch64
       type: rpm
       url: https://dl.fedoraproject.org/pub/epel/$releasever/Everything/aarch64/os/
       production: false
       debug: false
       priority: 10
-    - name: epel
+    - name: epel-10
       arch: ppc64le
       type: rpm
       url: https://dl.fedoraproject.org/pub/epel/$releasever/Everything/ppc64le/os/
       production: false
       debug: false
       priority: 10
-    - name: epel
+    - name: epel-10
       arch: s390x
       type: rpm
       url: https://dl.fedoraproject.org/pub/epel/$releasever/Everything/s390x/os/


### PR DESCRIPTION
This is to fix the:

```
Errors during downloading metadata for repository 'epel':
  - Status code: 404 for https://d2lzkl7pfhq30w.cloudfront.net/pub/epel/10/Everything/x86_64/repodata/repomd.xml (IP: 2600:9000:24d6:b400:f:49cb:b400:21)
Error: Failed to download metadata for repo 'epel': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried
```