### PR TITLE
Enable cross-releasing between platforms

### DIFF
--- a/alws/alembic/versions/63bc4e0b699f_add_many_to_many_relationship_between_.py
+++ b/alws/alembic/versions/63bc4e0b699f_add_many_to_many_relationship_between_.py
@@ -1,7 +1,7 @@
 """Add many to many relationship between platforms and sign_keys
 
 Revision ID: 63bc4e0b699f
-Revises: 764a67b23038
+Revises: 9977cc722e24
 Create Date: 2024-11-01 12:26:26.326314
 
 """

--- a/alws/middlewares/__init__.py
+++ b/alws/middlewares/__init__.py
@@ -2,6 +2,7 @@ from .builds import handlers as build_handlers
 from .not_found import handlers as not_found_handler
 from .permissions import handlers as perm_handlers
 from .products import handlers as product_handlers
+from .releases import handlers as release_handlers
 from .sign_task import handlers as sign_task_handlers
 from .uploads import handlers as upload_handlers
 
@@ -15,6 +16,7 @@ add_handlers = (
     product_handlers,
     sign_task_handlers,
     upload_handlers,
+    release_handlers,
 )
 handlers = {}
 for add_handler in add_handlers:

--- a/alws/middlewares/releases.py
+++ b/alws/middlewares/releases.py
@@ -1,0 +1,18 @@
+from fastapi import Request, status
+from fastapi.responses import JSONResponse
+
+from alws.errors import PlatformMissingError
+
+__all__ = ['handlers']
+
+
+async def incorrect_platform_error_handler(request: Request, exc):
+    return JSONResponse(
+        {'detail': str(exc)},
+        status_code=status.HTTP_400_BAD_REQUEST,
+    )
+
+
+handlers = {
+    PlatformMissingError: incorrect_platform_error_handler,
+}

--- a/alws/release_planner.py
+++ b/alws/release_planner.py
@@ -723,6 +723,7 @@ class CommunityReleasePlanner(BaseReleasePlanner):
         build_tasks: typing.Optional[typing.List[int]] = None,
         product: typing.Optional[models.Product] = None,
     ) -> dict:
+        self.base_platform = base_platform
         release_plan = {"modules": {}}
         added_packages = set()
 

--- a/alws/release_planner.py
+++ b/alws/release_planner.py
@@ -1519,7 +1519,7 @@ class AlmaLinuxReleasePlanner(BaseReleasePlanner):
                     is_devel=is_devel,
                     beholder_cache=beholder_cache,
                 )
-                # if we don't found repos for debug package, we can try to
+                # if we didn't find the repos for debug package, we can try to
                 # find repos by same package name but without debug suffix
                 if not repositories and is_debug:
                     repositories = self.find_release_repos(

--- a/alws/release_planner.py
+++ b/alws/release_planner.py
@@ -67,7 +67,7 @@ __all__ = [
 
 class BaseReleasePlanner(metaclass=ABCMeta):
     def __init__(self, db: AsyncSession):
-        self.base_platform = None  # type: typing.Optional[models.Platform]
+        self.base_platform: typing.Optional[models.Platform] = None
         self._db = db
         self.pulp_client = PulpClient(
             settings.pulp_host,

--- a/alws/release_planner.py
+++ b/alws/release_planner.py
@@ -269,7 +269,7 @@ class BaseReleasePlanner(metaclass=ABCMeta):
                 selectinload(models.Build.tasks)
                 .selectinload(models.BuildTask.rpm_modules),
                 selectinload(models.Build.repos)
-                .selectinload(models.Repository.platform)
+                .selectinload(models.Repository.platform),
             )
         )
         build_result = await self.db.execute(builds_q)
@@ -283,8 +283,9 @@ class BaseReleasePlanner(metaclass=ABCMeta):
                 ]
                 for build_rpm in rpms_list
                 if any(
-                    rp in reference_platforms for rp in
-                    build_rpm.artifact.build_task.platform.reference_platforms
+                    rp in reference_platforms
+                    for rp in build_rpm.artifact
+                    .build_task.platform.reference_platforms
                 )
             ]
             logging.info('Build RPMs "%s"', build_rpms)
@@ -345,8 +346,8 @@ class BaseReleasePlanner(metaclass=ABCMeta):
                         and not build_repo.debug
                         and build_repo.type == "rpm"
                         and any(
-                            rp in reference_platforms for rp in
-                            build_repo.platform.reference_platforms
+                            rp in reference_platforms
+                            for rp in build_repo.platform.reference_platforms
                         )
                     )
                     template = await self.pulp_client.get_repo_modules_yaml(

--- a/alws/routers/releases.py
+++ b/alws/routers/releases.py
@@ -2,7 +2,7 @@ import typing
 
 from fastapi import APIRouter, Depends
 from fastapi_sqla import AsyncSessionDependency
-from sqlalchemy import select, update
+from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from alws import models
@@ -64,6 +64,11 @@ async def create_new_release(
     db: AsyncSession = Depends(AsyncSessionDependency(key=get_async_db_key())),
     user: models.User = Depends(get_current_user),
 ):
+    await r_crud.check_compatible_platforms(
+        db,
+        payload.builds,
+        payload.platform_id,
+    )
     release = await r_crud.create_release(db, user.id, payload)
     return release
 

--- a/alws/utils/pulp_client.py
+++ b/alws/utils/pulp_client.py
@@ -796,7 +796,7 @@ class PulpClient:
             "proxy_password": proxy_password,
         }
 
-        await self.request("PATCH", remote_href, data=payload)
+        await self.request("PATCH", remote_href, json=payload)
         return remote_href
 
     async def sync_rpm_repo_from_remote(

--- a/reference_data/platforms.yaml
+++ b/reference_data/platforms.yaml
@@ -3401,6 +3401,8 @@
     - { name: ppc64le, depends_on: aarch64 }
     - { name: x86_64_v2, depends_on: x86_64 }
   data:
+    compatible_release_platforms:
+      - AlmaLinux-Kitten-10
     definitions:
       distribution: AlmaLinux
       packager: AlmaLinux Packaging Team <packager@almalinux.org>
@@ -5332,6 +5334,8 @@
     - { name: ppc64le, depends_on: aarch64 }
     - { name: x86_64_v2, depends_on: x86_64 }
   data:
+    compatible_release_platforms:
+      - AlmaLinux-10
     definitions:
       distribution: AlmaLinux
       packager: AlmaLinux Packaging Team <packager@almalinux.org>

--- a/scripts/exporters/packages_exporter.py
+++ b/scripts/exporters/packages_exporter.py
@@ -570,7 +570,7 @@ async def sign_repodata(
                         (
                             sign_key["keyid"]
                             for sign_key in db_sign_keys
-                            if sign_key["platform_id"] == platform_id
+                            if platform_id in sign_key["platform_ids"]
                         ),
                         None,
                     )
@@ -753,7 +753,7 @@ def main():
             (
                 sign_key["keyid"]
                 for sign_key in db_sign_keys
-                if sign_key["platform_id"] == platform_id
+                if platform_id in sign_key["platform_ids"]
             ),
             None,
         )

--- a/tests/fixtures/platforms.py
+++ b/tests/fixtures/platforms.py
@@ -4,6 +4,7 @@ import pytest
 import yaml
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from alws import models
 from alws.schemas import platform_schema, repository_schema
@@ -24,6 +25,9 @@ async def base_platform(
             await async_session.execute(
                 select(models.Platform).where(
                     models.Platform.name == schema["name"],
+                )
+                .options(
+                    selectinload(models.Platform.reference_platforms),
                 )
             )
         )


### PR DESCRIPTION
Resolves AlmaLinux/build-system#369:

- For cross-releasing we should include an RPM artifact...
...if the reference platforms of its build task has intersection with...
...the reference platform of base platform which we want to release a build