### PR TITLE
Fix bug with build search

### DIFF
--- a/alws/crud/build.py
+++ b/alws/crud/build.py
@@ -171,19 +171,9 @@ async def get_builds(
         if build_id is not None:
             query = query.where(models.Build.id == build_id)
         if project is not None:
-            project_name = project
-            project_query = query.filter(
-                sqlalchemy.or_(
-                    models.BuildTaskRef.url.like(f"%/{project_name}.git"),
-                    models.BuildTaskRef.url.like(f"%/{project_name}%.src.rpm"),
-                    models.BuildTaskRef.url.like(f"%/rpms/{project_name}%.git"),
-                )
+            query = query.filter(
+                models.BuildTaskRef.url.like(f"%/{project}%"),
             )
-            if not (await db.execute(project_query)).scalars().all():
-                project_query = query.filter(
-                    models.BuildTaskRef.url.like(f"%/{project_name}%"),
-                )
-            query = project_query
         if created_by is not None:
             query = query.filter(
                 models.Build.owner_id == created_by,


### PR DESCRIPTION
Resolves: https://github.com/AlmaLinux/build-system/issues/375
![image](https://github.com/user-attachments/assets/a8288a12-b273-469e-b7c9-e3547319c5f3)
We have some urls that do not correspond to our query filters and in result we do not get all existing builds