### PR TITLE
Remove codenotary repo from task-queue image

### DIFF
--- a/Dockerfile.task-queue
+++ b/Dockerfile.task-queue
@@ -1,7 +1,5 @@
 FROM almalinux/9-base:latest
 
-ADD https://packages.codenotary.org/codenotary.repo /etc/yum.repos.d/
-
 RUN <<EOT
   set -ex
   dnf upgrade -y


### PR DESCRIPTION
Codenotary repo currently returns 403, causing image builds to fail. Remove this as it is no longer needed since
97a503e14e655108d25af7608cd795bf24186481.

Fixes: https://github.com/AlmaLinux/build-system/issues/412