### PR TITLE
Fix Reset matched packages do not work on advisory with the same ID

### DIFF
--- a/alws/crud/errata.py
+++ b/alws/crud/errata.py
@@ -2432,12 +2432,19 @@ async def prepare_resetting(
         items_to_insert.extend(matching_packages)
 
 
-async def reset_matched_errata_packages(record_id: str, session: AsyncSession):
+async def reset_matched_errata_packages(
+    record_id: str,
+    platform_id: int,
+    session: AsyncSession,
+):
     record = (
         (
             await session.execute(
                 select(models.NewErrataRecord)
-                .where(models.NewErrataRecord.id == record_id)
+                .where(
+                    models.NewErrataRecord.id == record_id,
+                    models.NewErrataRecord.platform_id == platform_id,
+                )
                 .options(
                     selectinload(models.NewErrataRecord.platform).selectinload(
                         models.Platform.repos

--- a/alws/routers/errata.py
+++ b/alws/routers/errata.py
@@ -324,11 +324,16 @@ async def bulk_release_errata_records(
 @router.post('/reset-matched-packages')
 async def reset_matched_packages(
     record_id: str,
+    platform_id: int,
     session: AsyncSession = Depends(
         AsyncSessionDependency(key=get_async_db_key())
     ),
 ):
-    await errata_crud.reset_matched_errata_packages(record_id, session)
+    await errata_crud.reset_matched_errata_packages(
+        record_id,
+        platform_id,
+        session,
+    )
     return {'message': f'Packages for record {record_id} have been matched'}
 
 


### PR DESCRIPTION
Fixes: AlmaLinux/build-system#419