### PR TITLE
Add --nobest when building with Fedora-40-riscv64 flavor

### DIFF
--- a/reference_data/platform_flavors.yaml
+++ b/reference_data/platform_flavors.yaml
@@ -903,6 +903,10 @@
       priority: 10
 
 - name: Fedora-40-riscv64
+  data:
+    mock:
+      dnf_common_opts:
+        - --nobest
   repositories:
     - name: fedora-40-riscv64
       arch: riscv64


### PR DESCRIPTION
Required for bootstrapping AlmaLinux Kitten 10 RISC-V against Fedora 40