### PR TITLE
Update Fedora-40-riscv64 flavor

### DIFF
--- a/reference_data/platform_flavors.yaml
+++ b/reference_data/platform_flavors.yaml
@@ -914,13 +914,11 @@
     mock:
       dnf_common_opts:
         - --nobest
-    definitions:
-      __spec_check_template: "exit 0; "
   repositories:
     - name: fedora-40-riscv64
       arch: riscv64
       type: rpm
-      url: http://fedora.riscv.rocks/kojifiles/repos/f40-build/latest/riscv64/
+      url: https://repo.almalinux.org/development/almalinux/10/fedora-40-riscv64/
       production: false
       debug: false
       priority: 20


### PR DESCRIPTION
- Stop disabling tests
- Stop using Fedora RISC-V koji repo