### PR TITLE
Update Fedora-40-riscv64 flavor with dnf options

### DIFF
--- a/reference_data/platform_flavors.yaml
+++ b/reference_data/platform_flavors.yaml
@@ -914,6 +914,8 @@
     mock:
       dnf_common_opts:
         - --nobest
+        - --exclude fedora*
+        - --exclude perl*5.38*
   repositories:
     - name: fedora-40-riscv64
       arch: riscv64


### PR DESCRIPTION
Add excludes for fedora* and perl*5.38*