### PR TITLE
feat: use exponential backoff for Pulp task polling

### DIFF
--- a/alws/utils/pulp_client.py
+++ b/alws/utils/pulp_client.py
@@ -950,10 +950,17 @@ class PulpClient:
         info = await self.get_artifact(entity_href, include_fields=["sha256"])
         return entity_href, info["sha256"], artifact
 
-    async def wait_for_task(self, task_href: str, sleep_time: float = 5.0):
+    async def wait_for_task(
+        self,
+        task_href: str,
+        sleep_time: float = 0.5,
+        max_sleep: float = 10.0,
+    ):
         task = await self.request("GET", task_href)
+        current_sleep = sleep_time
         while task["state"] not in ("failed", "completed"):
-            await asyncio.sleep(sleep_time)
+            await asyncio.sleep(current_sleep)
+            current_sleep = min(current_sleep * 2, max(max_sleep, sleep_time))
             task = await self.request("GET", task_href)
         if task["state"] == "failed":
             error = task.get("error")


### PR DESCRIPTION
## Summary

- Replace fixed 5-second polling interval in `wait_for_task()` with exponential backoff: 0.5s, 1s, 2s, 4s, 8s, 10s, 10s...
- Most Pulp tasks (modify_repository, create content units, file uploads) complete in <1s but previously always waited 5s before first status check
- Backoff cap never goes below caller-provided `sleep_time`, so explicit long intervals (e.g. `sleep_time=30.0` for errata publications) are respected
- Pulp's own test suite uses 0.5s polling — no rate limiting on the task status endpoint

## Test plan

- [x] Full test suite passes (82 passed, 11 skipped)
- [ ] Verify fast Pulp tasks (modify_repository) complete detection in <1s
- [ ] Verify slow tasks (create_rpm_publication with sleep_time=30.0) still poll at 30s intervals
- [ ] Monitor Pulp API load under normal operations to confirm no increase