### PR TITLE
fix: skip repomd_signer test in GitHub Actions

### DIFF
--- a/tests/test_scripts/test_packages_exporter.py
+++ b/tests/test_scripts/test_packages_exporter.py
@@ -12,8 +12,8 @@ IN_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") is not None
 
 class TestPackagesExporter(BaseAsyncTestCase):
     @pytest.mark.skipif(
-        not settings.test_sign_key_id,
-        reason="Testing sign key is not provided",
+        not settings.test_sign_key_id or IN_GITHUB_ACTIONS,
+        reason="Testing sign key is not provided or sign_file service is unavailable",
     )
     async def test_repomd_signer(self, sign_key: SignKey, tmp_path):
         exporter = PackagesExporter(repodata_cache_dir='~/.cache/pulp_exporter')


### PR DESCRIPTION
The test_repomd_signer test requires the sign_file service to be reachable, which is not available in the GitHub Actions CI environment. The GITHUB_ACTIONS env var was already detected but unused. Add it to the skipif condition so the test is skipped when the service is unavailable.