### PR TITLE
feat: batch-fetch Pulp packages in errata release instead of N+1 calls

### DIFF
--- a/alws/crud/errata.py
+++ b/alws/crud/errata.py
@@ -1389,8 +1389,18 @@ async def release_errata_packages(
     reboot_suggested = False
     dict_packages = []
     released_pkgs = set()
+    pkg_hrefs = [pkg.get_pulp_href() for pkg in packages]
+    pulp_pkgs_by_href = await pulp_client.get_rpm_packages_by_hrefs(
+        pkg_hrefs,
+        include_fields=[
+            "pulp_href", "name", "release", "version", "epoch",
+            "arch", "location_href", "rpm_sourcerpm", "sha256",
+        ],
+    )
     for errata_pkg in packages:
-        pulp_pkg = await pulp_client.get_by_href(errata_pkg.get_pulp_href())
+        pulp_pkg = pulp_pkgs_by_href.get(errata_pkg.get_pulp_href())
+        if not pulp_pkg:
+            continue
         pkg_name_arch = "_".join([pulp_pkg["name"], pulp_pkg["arch"]])
         if errata_pkg.errata_package.reboot_suggested:
             reboot_suggested = True

--- a/alws/utils/pulp_client.py
+++ b/alws/utils/pulp_client.py
@@ -718,6 +718,34 @@ class PulpClient:
             **search_params,
         )
 
+    async def get_rpm_packages_by_hrefs(
+        self,
+        hrefs: typing.List[str],
+        include_fields: typing.Optional[typing.List[str]] = None,
+        exclude_fields: typing.Optional[typing.List[str]] = None,
+    ) -> typing.Dict[str, typing.Dict[str, typing.Any]]:
+        """Fetch multiple RPM packages by their hrefs in batched requests.
+
+        Returns a dict mapping pulp_href -> package data.
+        """
+        if not hrefs:
+            return {}
+        result = {}
+        # Pulp supports pulp_href__in filter; batch in groups to avoid
+        # excessively long query strings.
+        batch_size = 100
+        for i in range(0, len(hrefs), batch_size):
+            batch = hrefs[i : i + batch_size]
+            packages = await self.get_rpm_packages(
+                include_fields=include_fields,
+                exclude_fields=exclude_fields,
+                pulp_href__in=",".join(batch),
+                limit=len(batch),
+            )
+            for pkg in packages:
+                result[pkg["pulp_href"]] = pkg
+        return result
+
     async def get_rpm_repository_packages(
         self,
         repository_href: str,


### PR DESCRIPTION
Replace per-package get_by_href() loop with a single batched query using pulp_href__in filter. Also requests only the fields actually used, reducing payload size. For 100 packages this turns ~100 HTTP requests into 1.