### PR TITLE
Enable shared yum cache and caching options for AlmaLinux-Kitten-10

### DIFF
--- a/reference_data/platforms.yaml
+++ b/reference_data/platforms.yaml
@@ -5542,6 +5542,7 @@
         - '--rlimit=RLIMIT_NOFILE=20480'
         - '--capability=cap_ipc_lock'
       rpmautospec_enable: true
+      use_shared_yum_cache: true
       secure_boot_macros:
         "%with_modsign": "1"
         "%modsign_os": "almalinux10"
@@ -5551,6 +5552,8 @@
     timeout: 172800
     yum:
       best: true
+      keepcache: true
+      metadata_expire: 60
       module_platform_id: platform:el10
   repositories:
     - arch: s390x


### PR DESCRIPTION
## Summary
- Add `use_shared_yum_cache: true` to AlmaLinux-Kitten-10 mock config so builds share a yum cache keyed by platform name and architecture
- Add `keepcache: true` and `metadata_expire: 60` to AlmaLinux-Kitten-10 yum config for build caching

**Depends on:** AlmaLinux/albs-node#221 (shared yum cache handling in build node)

Fixes AlmaLinux/build-system#527

## Test plan
- [ ] Verify AlmaLinux-Kitten-10 builds use shared yum cache with correct cache key
- [ ] Verify yum.conf includes `keepcache = 1` and `metadata_expire = 60`
- [ ] Verify other platforms are unaffected