### PR TITLE
Add missing alembic volume mounts for sign_file service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -563,6 +563,8 @@ services:
       - "../albs-sign-file/sign:/app/sign"
       - "../albs-sign-file/start.py:/app/start.py"
       - "../albs-sign-file/db_manage.py:/app/db_manage.py"
+      - "../albs-sign-file/alembic.ini:/app/alembic.ini"
+      - "../albs-sign-file/alembic:/app/alembic"
     ports:
       - "8083:8000"
     logging:


### PR DESCRIPTION
The sign_file service's db_manage.py runs alembic migrations on startup, but the alembic.ini config and alembic/ migrations directory were not mounted into the container, causing startup failure with: "No 'script_location' key found in configuration."