### PR TITLE
Set %_smp_build_ncpus to nproc for AlmaLinux-8

### DIFF
--- a/reference_data/platforms.yaml
+++ b/reference_data/platforms.yaml
@@ -53,6 +53,7 @@
         - '--capability=cap_ipc_lock'
       macros:
         "%bcond()": '%{expand:%%bcond_%{lua:if "%2"=="1" then print("without") else print("with") end} %1}'
+        "%_smp_build_ncpus": '%(nproc)'
       secure_boot_macros:
         "%with_modsign": "1"
         "%modsign_os": "almalinux8"


### PR DESCRIPTION
NUMA-pinned build workers in albs-node confine each build to a single NUMA node via sched_setaffinity. RPM's default %{?_smp_mflags} is derived from getconf _NPROCESSORS_ONLN, which is not affinity-aware and therefore reports the host-wide CPU count, causing kernel and similar make-based builds to spawn make -j<host-cpus> even when pinned. Using "%(nproc)" lets RPM call nproc(1), which respects sched_getaffinity and reports the per-node CPU count.