### PR TITLE
Add AlmaLinux 9.8 platform version

### DIFF
--- a/reference_data/platforms.yaml
+++ b/reference_data/platforms.yaml
@@ -1787,6 +1787,9 @@
       - name: '9.7'
         version_prefix: '90700'
         dist_prefix: 'el9.7.0'
+      - name: '9.8'
+        version_prefix: '90800'
+        dist_prefix: 'el9.8.0'
     yum:
       best: true
       module_platform_id: platform:el9


### PR DESCRIPTION
## Summary
- Add `9.8` version entry to AlmaLinux-9 platform in `reference_data/platforms.yaml` (with `version_prefix: 90800` and `dist_prefix: el9.8.0`)

## Test plan
- [ ] Confirm 9.8 appears in available platform versions after reference data sync