### PR TITLE
Make build task expiration timeout configurable

### DIFF
--- a/alws/config.py
+++ b/alws/config.py
@@ -93,6 +93,8 @@ class Settings(BaseSettings):
 
     logging_level: Optional[str] = 'INFO'
 
+    build_task_expiration_minutes: int = 20
+
     frontend_baseurl: Annotated[str, Field(validate_default=True)] = (
         'http://localhost:8080'
     )

--- a/alws/crud/build_node.py
+++ b/alws/crud/build_node.py
@@ -44,8 +44,9 @@ async def get_available_build_task(
     db: AsyncSession,
     request: build_node_schema.RequestTask,
 ) -> typing.Optional[models.BuildTask]:
-    # TODO: here should be config value
-    ts_expired = datetime.datetime.utcnow() - datetime.timedelta(minutes=20)
+    ts_expired = datetime.datetime.utcnow() - datetime.timedelta(
+        minutes=settings.build_task_expiration_minutes
+    )
     exclude_condition = (
         sqlalchemy.not_(
             sqlalchemy.or_(*[


### PR DESCRIPTION
The time before an in-progress build task is considered expired was hard coded to 20 minutes in get_available_build_task. This moves it into a new build_task_expiration_minutes setting (default 20), so behavior is unchanged unless it's overridden.

This is the web server / app half of https://github.com/AlmaLinux/build-system/issues/284

Fixes: https://github.com/AlmaLinux/build-system/issues/284