### PR TITLE
Run Pulp as a multi-container stack in docker-compose

### DIFF
--- a/assets/pulp/bin/nginx.sh
+++ b/assets/pulp/bin/nginx.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# This logic enables us to have multiple servers, and check to see
+# if they are scaled every 10 seconds.
+# https://serverfault.com/a/821625/189494
+# https://www.nginx.com/blog/dns-service-discovery-nginx-plus#domain-name-variable
+
+set -e
+
+if [ "$container" == "podman" ]; then
+  # the nameserver list under podman is unreliable.
+  # It will look like "10.89.1.1 192.168.1.1 192.168.1.1", but only the 1st IP works.
+  # This doesn't mess up `nslookup`, but it messes up `getent hosts` and nginx.
+  export NAMESERVER=`cat /etc/resolv.conf | grep "nameserver" | awk '{print $2}' | head -n1`
+else
+  export NAMESERVER=`cat /etc/resolv.conf | grep "nameserver" | awk '{print $2}' | tr '\n' ' '`
+fi
+
+echo "Nameserver is: $NAMESERVER"
+
+echo "Generating nginx config"
+envsubst '$NAMESERVER' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
+
+# Note: the nginx.conf.template already proxies to $pulp_api:24817 /
+# $pulp_content:24816 via the resolver, so no per-file rewrite of
+# /etc/nginx/pulp/*.conf is needed (and that dir is empty in pulp-web).
+
+echo "Starting nginx"
+exec nginx  -g "daemon off;"

--- a/assets/pulp/certs/.gitignore
+++ b/assets/pulp/certs/.gitignore
@@ -1,0 +1,4 @@
+# Keep this dir tracked but never commit generated keys/certs (secrets).
+*
+!.gitkeep
+!.gitignore

--- a/assets/pulp/certs/.gitkeep
+++ b/assets/pulp/certs/.gitkeep
@@ -1,0 +1,2 @@
+# Pulp writes database_fields.symmetric.key here on first migration.
+# Back this directory up — losing the key makes encrypted DB fields unrecoverable.

--- a/assets/pulp/nginx/nginx.conf.template
+++ b/assets/pulp/nginx/nginx.conf.template
@@ -1,0 +1,90 @@
+# pulp-web nginx config template. $NAMESERVER is substituted by nginx.sh at
+# container start; $pulp_api / $pulp_content stay as nginx variables so the
+# resolver can pick up scaled replicas every 10s.
+error_log /dev/stdout info;
+worker_processes 1;
+events {
+    worker_connections 1024; # increase if you have lots of clients
+    accept_mutex off; # set to 'on' if nginx worker_processes > 1
+}
+
+http {
+    access_log /dev/stdout;
+    include mime.types;
+    # fallback in case we can't determine a type
+    default_type application/octet-stream;
+    sendfile on;
+
+    # If left at the default of 1024, nginx emits a warning about being unable
+    # to build optimal hash types.
+    types_hash_max_size 4096;
+
+    server {
+        # This logic enables us to have multiple servers, and check to see
+        # if they are scaled every 10 seconds.
+        resolver $NAMESERVER valid=10s;
+        set $pulp_api pulp_api;
+        set $pulp_content pulp_content;
+
+        # Gunicorn docs suggest the use of the "deferred" directive on Linux.
+        listen 80 default_server deferred;
+        listen [::]:80 default_server deferred;
+
+        # If you have a domain name, this is where to add it
+        server_name $hostname;
+
+        # The default client_max_body_size is 1m. Clients uploading
+        # files larger than this will need to chunk said files.
+        client_max_body_size 10m;
+
+        # Gunicorn docs suggest this value.
+        keepalive_timeout 5;
+
+        # static files that can change dynamically, or are needed for TLS
+        # purposes are served through the webserver.
+        root /opt/app-root/src;
+
+        location /pulp/content/ {
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Host $http_host;
+            # we don't want nginx trying to do something clever with
+            # redirects, we set the Host: header above already.
+            proxy_redirect off;
+            proxy_pass http://$pulp_content:24816;
+        }
+
+        location /pulp/api/v3/ {
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Host $http_host;
+            # we don't want nginx trying to do something clever with
+            # redirects, we set the Host: header above already.
+            proxy_redirect off;
+            proxy_pass http://$pulp_api:24817;
+        }
+
+        location /auth/login/ {
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Host $http_host;
+            # we don't want nginx trying to do something clever with
+            # redirects, we set the Host: header above already.
+            proxy_redirect off;
+            proxy_pass http://$pulp_api:24817;
+        }
+
+        include /etc/nginx/pulp/*.conf;
+
+        location / {
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Host $http_host;
+            # we don't want nginx trying to do something clever with
+            # redirects, we set the Host: header above already.
+            proxy_redirect off;
+            proxy_pass http://$pulp_api:24817;
+            # static files are served through whitenoise - http://whitenoise.evans.io/en/stable/
+        }
+    }
+}

--- a/assets/pulp/settings.py
+++ b/assets/pulp/settings.py
@@ -1,0 +1,46 @@
+# Pulp settings for the local docker-compose multi-container stack.
+# Mounted at /etc/pulp/settings.py in every pulp-minimal/pulp-web service.
+# Reference: https://pulpproject.org/pulpcore/docs/admin/reference/settings/
+#
+# DEV ONLY — these values match the local docker-compose defaults
+# (postgres/password, admin/password). Do not reuse them anywhere real.
+
+SECRET_KEY = "albs-local-dev-pulp-secret-key-not-for-production"
+CONTENT_ORIGIN = "http://pulp"
+
+DATABASES = {
+    "default": {
+        "HOST": "postgres",
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": "pulp",
+        "USER": "postgres",
+        "PASSWORD": "password",
+        "PORT": "5432",
+        "CONN_MAX_AGE": 0,
+        "OPTIONS": {"sslmode": "prefer"},
+    }
+}
+
+CACHE_ENABLED = True
+# Renamed from "redis" to avoid a service-name clash with the ALBS redis in the
+# same compose project.
+REDIS_HOST = "pulp_redis"
+REDIS_PORT = 6379
+REDIS_PASSWORD = ""
+
+ANSIBLE_API_HOSTNAME = "http://pulp_api:24817"
+ANSIBLE_CONTENT_HOSTNAME = "http://pulp_content:24816/pulp/content"
+
+# PulpExport / PulpImport (matches the ../volumes/pulp/exports bind mount).
+ALLOWED_IMPORT_PATHS = ["/srv/exports", "/tmp"]
+ALLOWED_EXPORT_PATHS = ["/srv/exports", "/tmp"]
+
+# pulp_container token auth
+TOKEN_SERVER = "http://pulp_api:24817/token/"
+TOKEN_AUTH_DISABLED = False
+TOKEN_SIGNATURE_ALGORITHM = "ES256"
+PUBLIC_KEY_PATH = "/etc/pulp/keys/container_auth_public_key.pem"
+PRIVATE_KEY_PATH = "/etc/pulp/keys/container_auth_private_key.pem"
+
+ANALYTICS = False
+STATIC_ROOT = "/var/lib/operator/static/"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,21 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Pulp runs as a scalable multi-container stack (pulp-minimal + pulp-web), based
+# on pulp-oci-images, instead of the old all-in-one pulp/pulp image.
+#
+# The services that talk to Pulp (web_server + the task_queue_* workers) read
+# their Pulp config from vars.env (env_file). For the dev stack, vars.env MUST
+# set these to reach the stack below — NOT the test_db defaults:
+#   PULP_HOST=http://pulp                  # pulp_web alias, nginx on :80. Do NOT
+#                                          # use "pulp_web": Django rejects the
+#                                          # underscore in the Host header.
+#   PULP_USER=admin
+#   PULP_PASSWORD=password
+#   PULP_DATABASE_URL=postgresql+psycopg2://postgres:password@postgres:5432/pulp
+#   PULP_ASYNC_DATABASE_URL=postgresql+asyncpg://postgres:password@postgres:5432/pulp
+#   FASTAPI_SQLA__PULP__SQLALCHEMY_URL=postgresql+psycopg2://postgres:password@postgres:5432/pulp
+#   FASTAPI_SQLA__PULP_ASYNC__SQLALCHEMY_URL=postgresql+asyncpg://postgres:password@postgres:5432/pulp
+# (tests/test-vars.env keeps these pointed at test_db for the test suite.)
+# ─────────────────────────────────────────────────────────────────────────────
 services:
 
   test_db:
@@ -132,7 +150,7 @@ services:
     restart: on-failure
     depends_on:
       - db
-      - pulp
+      - pulp_api
     logging:
       driver: "json-file"
       options:
@@ -156,7 +174,7 @@ services:
     restart: on-failure
     depends_on:
       - db
-      - pulp
+      - pulp_api
       - rabbitmq
     logging:
       driver: "json-file"
@@ -181,7 +199,7 @@ services:
     restart: on-failure
     depends_on:
       - db
-      - pulp
+      - pulp_api
       - rabbitmq
     logging:
       driver: "json-file"
@@ -206,7 +224,7 @@ services:
     restart: on-failure
     depends_on:
       - db
-      - pulp
+      - pulp_api
       - rabbitmq
     logging:
       driver: "json-file"
@@ -231,7 +249,7 @@ services:
     restart: on-failure
     depends_on:
       - db
-      - pulp
+      - pulp_api
       - rabbitmq
     logging:
       driver: "json-file"
@@ -256,7 +274,7 @@ services:
     restart: on-failure
     depends_on:
       - db
-      - pulp
+      - pulp_api
       - rabbitmq
     logging:
       driver: "json-file"
@@ -315,7 +333,7 @@ services:
     restart: on-failure
     depends_on:
       - db
-      - pulp
+      - pulp_api
       - rabbitmq
     logging:
       driver: "json-file"
@@ -463,30 +481,208 @@ services:
         max-size: "100Mb"
         max-file: "3"
 
-  pulp:
-    image: pulp/pulp:3.49.1
+  # ───────────────────────────────────────────────────────────────────────────
+  # Pulp — scalable multi-container stack (pulp-minimal + pulp-web), replacing
+  # the old all-in-one pulp/pulp image. Config assets live under ./assets/pulp/.
+  # The ALBS services reach this via vars.env (host "pulp", DB "postgres") — see
+  # the PULP_* notes at the top of this file. DEV ONLY: postgres/password,
+  # admin/password.
+  # ───────────────────────────────────────────────────────────────────────────
+  postgres:
+    image: postgres:16
     ports:
-      - 8081:80
-      - 5431:5432
+      - "5431:5432"   # host:container — keeps the old all-in-one's external port
+    env_file:
+      - pulp-postgres.env
     volumes:
-      - "../volumes/pulp/settings:/etc/pulp:z"
-      - "../volumes/pulp/exports:/srv/exports:z"
-      - "../volumes/pulp/pulp_storage:/var/lib/pulp:z"
-      - "../volumes/pulp/pgsql:/var/lib/pgsql:z"
-      - "../volumes/pulp/containers:/var/lib/containers:z"
-      - "./pulp_init.sh:/usr/local/bin/pulp_init.sh:z"
-    devices:
-      - "/dev/fuse"
-    restart: on-failure
+      - "../volumes/pulp/pgsql_16:/var/lib/postgresql/data:z"
+    restart: always
+    healthcheck:
+      test: pg_isready -U postgres
+      interval: 10s
+      timeout: 5s
+      retries: 5
     logging:
       driver: "json-file"
       options:
         max-size: "100Mb"
         max-file: "3"
-    #  echo "listen_addresses = '*'" >> /var/lib/pgsql/data/postgresql.conf &&
-    #  echo "host all all 0.0.0.0/0 md5" >> /var/lib/pgsql/data/pg_hba.conf &&
-    #  echo "host all all ::/0 md5" >> /var/lib/pgsql/data/pg_hba.conf &&
-    #  runuser postgres -c 'echo "ALTER USER postgres WITH PASSWORD '"'"'password'"'"';" | /usr/bin/psql'
+
+  pulp_redis:
+    image: redis
+    volumes:
+      - "pulp_redis:/data"
+    restart: always
+    healthcheck:
+      test: redis-cli ping
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "100Mb"
+        max-file: "3"
+
+  pulp_migration:
+    image: pulp/pulp-minimal:3.49.1
+    # pulp-minimal (unlike the old all-in-one image) does NOT auto-generate the
+    # DB field-encryption key. Generate it here on first run if missing, then
+    # migrate. The key persists in the ./assets/pulp/certs bind mount — back it
+    # up; losing it makes encrypted DB fields unrecoverable.
+    command: |
+      bash -c "
+        set -e
+        if [ ! -s /etc/pulp/certs/database_fields.symmetric.key ]; then
+          echo 'Generating Pulp DB encryption key...'
+          python3 -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())' > /etc/pulp/certs/database_fields.symmetric.key
+          chmod 0644 /etc/pulp/certs/database_fields.symmetric.key
+        fi
+        pulpcore-manager migrate --noinput"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    volumes:
+      - "./assets/pulp/settings.py:/etc/pulp/settings.py:z"
+      - "./assets/pulp/certs:/etc/pulp/certs:z"
+      - "pulp_storage:/var/lib/pulp"
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "100Mb"
+        max-file: "3"
+
+  pulp_set_init_password:
+    image: pulp/pulp-minimal:3.49.1
+    command: set_init_password.sh
+    depends_on:
+      postgres:
+        condition: service_healthy
+      pulp_migration:
+        condition: service_completed_successfully
+    environment:
+      PULP_DEFAULT_ADMIN_PASSWORD: password
+    volumes:
+      - "./assets/pulp/settings.py:/etc/pulp/settings.py:z"
+      - "./assets/pulp/certs:/etc/pulp/certs:z"
+      - "pulp_storage:/var/lib/pulp"
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "100Mb"
+        max-file: "3"
+
+  pulp_api:
+    image: pulp/pulp-minimal:3.49.1
+    command: ['pulp-api']
+    hostname: pulp-api
+    user: pulp
+    depends_on:
+      postgres:
+        condition: service_healthy
+      pulp_redis:
+        condition: service_healthy
+      pulp_migration:
+        condition: service_completed_successfully
+      pulp_set_init_password:
+        condition: service_completed_successfully
+    volumes:
+      - "./assets/pulp/settings.py:/etc/pulp/settings.py:z"
+      - "./assets/pulp/certs:/etc/pulp/certs:z"
+      - "pulp_storage:/var/lib/pulp"
+      - "../volumes/pulp/exports:/srv/exports:z"
+    restart: always
+    healthcheck:
+      test: readyz.py /pulp/api/v3/status/
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 90s
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "100Mb"
+        max-file: "3"
+
+  pulp_content:
+    image: pulp/pulp-minimal:3.49.1
+    command: ['pulp-content']
+    hostname: pulp-content
+    user: pulp
+    depends_on:
+      postgres:
+        condition: service_healthy
+      pulp_redis:
+        condition: service_healthy
+      pulp_migration:
+        condition: service_completed_successfully
+    volumes:
+      - "./assets/pulp/settings.py:/etc/pulp/settings.py:z"
+      - "./assets/pulp/certs:/etc/pulp/certs:z"
+      - "pulp_storage:/var/lib/pulp"
+    restart: always
+    healthcheck:
+      test: readyz.py /pulp/content/
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 90s
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "100Mb"
+        max-file: "3"
+
+  pulp_worker:
+    image: pulp/pulp-minimal:3.49.1
+    command: ['pulp-worker']
+    user: pulp
+    depends_on:
+      postgres:
+        condition: service_healthy
+      pulp_redis:
+        condition: service_healthy
+      pulp_migration:
+        condition: service_completed_successfully
+    volumes:
+      - "./assets/pulp/settings.py:/etc/pulp/settings.py:z"
+      - "./assets/pulp/certs:/etc/pulp/certs:z"
+      - "pulp_storage:/var/lib/pulp"
+      - "../volumes/pulp/exports:/srv/exports:z"
+    restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "100Mb"
+        max-file: "3"
+
+  # nginx front end. Aliased to "pulp" so ALBS can reach it at http://pulp (the
+  # old all-in-one service name); listens on :80 internally.
+  pulp_web:
+    image: pulp/pulp-web:3.49.1
+    command: ['/usr/bin/nginx.sh']
+    hostname: pulp
+    user: root
+    ports:
+      - "8081:80"   # host:container — browse Pulp at http://localhost:8081/
+    depends_on:
+      pulp_api:
+        condition: service_healthy
+      pulp_content:
+        condition: service_healthy
+    networks:
+      default:
+        aliases:
+          - pulp
+    volumes:
+      - "./assets/pulp/bin/nginx.sh:/usr/bin/nginx.sh:Z"
+      - "./assets/pulp/nginx/nginx.conf.template:/etc/nginx/nginx.conf.template:Z"
+    restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "100Mb"
+        max-file: "3"
 
   mosquitto:
     image: eclipse-mosquitto:2.0
@@ -573,3 +769,8 @@ services:
 
 volumes:
   redis:
+  pulp_redis:
+  # Pulp content store. Named volume (not a host bind mount) so Docker populates
+  # it from the image — preserving /var/lib/pulp/tmp and the uid:700 (pulp)
+  # ownership the pulp-minimal services need.
+  pulp_storage:

--- a/pulp-postgres.env
+++ b/pulp-postgres.env
@@ -1,0 +1,8 @@
+# Bootstrap vars for the Pulp PostgreSQL server (postgres:16 image, first boot).
+# Server-side config — distinct from vars.env's POSTGRES_* (which bootstrap
+# ALBS's own db/test_db with database "test-almalinux-bs"). DEV ONLY.
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=password
+POSTGRES_DB=pulp
+POSTGRES_INITDB_ARGS=--auth-host=scram-sha-256
+POSTGRES_HOST_AUTH_METHOD=scram-sha-256


### PR DESCRIPTION
Replace the all-in-one pulp/pulp image with the scalable pulp-minimal + pulp-web topology (postgres, redis, migration/init one-shots, api, content, worker, web), based on pulp-oci-images.

- ALBS services reach Pulp via vars.env (http://pulp for HTTP, the separate postgres service for the DB) instead of an inline compose anchor.
- pulp_migration generates the DB field-encryption key on first run, since pulp-minimal (unlike the all-in-one image) does not.
- Pulp content store uses a named volume so the image's tmp/ and uid:700 ownership are preserved.
- Pulp DB bootstrap vars live in pulp-postgres.env; config assets (settings.py, nginx template + launcher) under assets/pulp/. Generated keys stay untracked.