### PR TITLE
Make Swagger UI 'Try it out' optional, disabled by default

### DIFF
--- a/alws/app.py
+++ b/alws/app.py
@@ -29,7 +29,14 @@ AUTH_TAG = 'auth'
 sentry_init()
 
 
-app = FastAPI()
+# Unless explicitly enabled (dev/local), disable Swagger UI "Try it out" so that
+# no endpoint (and especially no mutating one) can be executed against the live
+# server from /docs. The schema stays fully browsable; it's just not callable.
+swagger_ui_parameters = None
+if not settings.swagger_try_it_out_enabled:
+    swagger_ui_parameters = {"supportedSubmitMethods": []}
+
+app = FastAPI(swagger_ui_parameters=swagger_ui_parameters)
 app.add_event_handler("startup", limiter_startup)
 app.add_event_handler("shutdown", limiter_shutdown)
 app.add_middleware(ExceptionMiddleware, handlers=handlers)

--- a/alws/config.py
+++ b/alws/config.py
@@ -91,6 +91,11 @@ class Settings(BaseSettings):
 
     documentation_path: str = 'alws/documentation/'
 
+    # When False, the Swagger UI "Try it out" button is removed from /docs so
+    # that endpoints can't be executed against the live server. Enable it only
+    # on dev/local environments.
+    swagger_try_it_out_enabled: bool = False
+
     logging_level: Optional[str] = 'INFO'
 
     frontend_baseurl: Annotated[str, Field(validate_default=True)] = (


### PR DESCRIPTION
Add a swagger_try_it_out_enabled setting (default False). When it's not enabled, the FastAPI app is created with supportedSubmitMethods=[] so the Swagger UI execute button is removed and endpoints can't be run against the live server from /docs. The schema stays browsable.

Closes AlmaLinux/build-system#538