### PR TITLE
fix: process all platforms in bootstrap_repositories

### DIFF
--- a/scripts/bootstrap_repositories.py
+++ b/scripts/bootstrap_repositories.py
@@ -473,7 +473,6 @@ async def main_async():
                 repos_to_sync.append(sync_info)
         if repos_to_sync and not args.no_sync:
             await sync_repositories(repos_to_sync, pulp_client)
-            return
         await add_repositories_to_platform(platform_data, repository_ids)
         await add_owner_id()
 


### PR DESCRIPTION
Remove the premature return after sync_repositories so the loop no longer exits after the first platform with repos to sync. This ensures add_repositories_to_platform and add_owner_id run for every platform.