### PR TITLE
Fix start_build enqueue race by committing before sending

### DIFF
--- a/alws/crud/build.py
+++ b/alws/crud/build.py
@@ -88,6 +88,14 @@ async def create_build(
             db_build.platform_flavors.append(flavour)
     db.add(db_build)
     await db.flush()
+    # Commit before enqueueing so the build row is durable when the dramatiq
+    # worker looks it up. Sending inside the still-open request transaction
+    # races the worker: it can query the build before the row is committed (or
+    # after a rollback) and crash with "'NoneType' object has no attribute
+    # 'id'" in BuildPlanner.
+    await db.commit()
+    # commit expires the instance (expire_on_commit=True); refresh so the
+    # response model can read id/created_at/mock_options without a lazy load.
     await db.refresh(db_build)
     start_build.send(db_build.id, build.model_dump())
     return db_build


### PR DESCRIPTION
Enqueueing start_build inside the still-open request transaction races the dramatiq worker: it could look up the build before the row was committed (or after a rollback), receiving None and crashing with 'NoneType' object has no attribute 'id' in BuildPlanner._add_single_project.

Commit the build row before publishing the message so it is durable when the worker fetches it, and refresh the expired instance so the response model can read its columns without an async lazy-load.