### PR TITLE
Fix start_build enqueue race by committing before sending

### DIFF
--- a/alws/crud/build.py
+++ b/alws/crud/build.py
@@ -88,6 +88,7 @@ async def create_build(
             db_build.platform_flavors.append(flavour)
     db.add(db_build)
     await db.flush()
+    await db.commit()
     await db.refresh(db_build)
     start_build.send(db_build.id, build.model_dump())
     return db_build


### PR DESCRIPTION
Enqueueing start_build inside the still-open request transaction races the dramatiq worker: it could look up the build before the row was committed (or after a rollback), receiving None and crashing with 'NoneType' object has no attribute 'id' in BuildPlanner._add_single_project.

Commit the build row before publishing the message so it is durable when the worker fetches it, and refresh the expired instance so the response model can read its columns without an async lazy-load.