### PR TITLE
Upgrade Pulp to 3.114.1 and drop redundant dramatiq Prometheus middleware

### DIFF
--- a/alws/dramatiq/__init__.py
+++ b/alws/dramatiq/__init__.py
@@ -16,7 +16,6 @@ import asyncio
 
 import dramatiq
 from dramatiq.brokers.rabbitmq import RabbitmqBroker
-from dramatiq.middleware.prometheus import Prometheus
 
 from alws.config import settings
 
@@ -27,11 +26,10 @@ rabbitmq_broker = RabbitmqBroker(
     f"{settings.rabbitmq_default_host}:5672/"
     f"{settings.rabbitmq_default_vhost}",
 )
-# Instruments every actor with per-task duration/count/error/retry metrics
-# (queue_name, actor_name labels) and serves them on :9191 per worker process.
-# Metrics from alws.utils.metrics (track_time) ride the same multiprocess
-# exposition when PROMETHEUS_MULTIPROC_DIR is set in the worker environment.
-rabbitmq_broker.add_middleware(Prometheus())
+# Per-actor Prometheus metrics (duration/count/error/retry, served on :9191)
+# are provided automatically by the dramatiq worker CLI's default Prometheus
+# middleware whenever prometheus_client is installed — we do NOT add it here,
+# since a second explicit registration duplicates the collectors and conflicts.
 dramatiq.set_broker(rabbitmq_broker)
 event_loop = asyncio.get_event_loop()
 

--- a/alws/utils/metrics.py
+++ b/alws/utils/metrics.py
@@ -5,8 +5,9 @@ This module owns the metric definitions, the ASGI app exposed at ``/metrics``,
 the HTTP middleware that times every request, and a generic ``track_time``
 decorator for instrumenting arbitrary sync/async functions.
 
-Dramatiq workers run in separate processes and are instrumented separately
-(see ``alws/dramatiq/__init__.py``); they do not go through this middleware.
+Dramatiq workers run in separate processes and are instrumented separately by
+the dramatiq worker CLI's built-in Prometheus middleware; they do not go
+through this middleware.
 """
 
 import asyncio

--- a/alws/utils/pulp_client.py
+++ b/alws/utils/pulp_client.py
@@ -24,7 +24,7 @@ from alws.constants import UPLOAD_FILE_CHUNK_SIZE
 from alws.utils.file_utils import hash_content, hash_file
 from alws.utils.ids import get_random_unique_version
 
-PULP_SEMAPHORE = asyncio.Semaphore(5)
+PULP_SEMAPHORE = asyncio.Semaphore(20)
 
 
 class PulpClient:
@@ -304,6 +304,7 @@ class PulpClient:
             "artifacts": artifacts,
             "dependencies": dependencies,
             "profiles": profiles,
+            "packages": [],
         }
         if packages:
             payload["packages"] = packages
@@ -692,12 +693,7 @@ class PulpClient:
             new_url = result.get("next")
             parsed_url = urllib.parse.urlsplit(new_url)
             new_url = parsed_url.path + "?" + parsed_url.query
-            result = await self.__get_content_info(
-                new_url,
-                include_fields=include_fields,
-                exclude_fields=exclude_fields,
-                **search_params,
-            )
+            result = await self.request("GET", new_url)
             all_entities.extend(result["results"])
         return all_entities
 
@@ -950,7 +946,7 @@ class PulpClient:
         info = await self.get_artifact(entity_href, include_fields=["sha256"])
         return entity_href, info["sha256"], artifact
 
-    async def wait_for_task(self, task_href: str, sleep_time: float = 5.0):
+    async def wait_for_task(self, task_href: str, sleep_time: float = 1.0):
         task = await self.request("GET", task_href)
         while task["state"] not in ("failed", "completed"):
             await asyncio.sleep(sleep_time)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -525,7 +525,7 @@ services:
         max-file: "3"
 
   pulp_migration:
-    image: pulp/pulp-minimal:3.49.1
+    image: pulp/pulp-minimal:3.114.1
     # pulp-minimal (unlike the old all-in-one image) does NOT auto-generate the
     # DB field-encryption key. Generate it here on first run if missing, then
     # migrate. The key persists in the ./assets/pulp/certs bind mount — back it
@@ -553,7 +553,7 @@ services:
         max-file: "3"
 
   pulp_set_init_password:
-    image: pulp/pulp-minimal:3.49.1
+    image: pulp/pulp-minimal:3.114.1
     command: set_init_password.sh
     depends_on:
       postgres:
@@ -573,7 +573,7 @@ services:
         max-file: "3"
 
   pulp_api:
-    image: pulp/pulp-minimal:3.49.1
+    image: pulp/pulp-minimal:3.114.1
     command: ['pulp-api']
     hostname: pulp-api
     user: pulp
@@ -605,7 +605,7 @@ services:
         max-file: "3"
 
   pulp_content:
-    image: pulp/pulp-minimal:3.49.1
+    image: pulp/pulp-minimal:3.114.1
     command: ['pulp-content']
     hostname: pulp-content
     user: pulp
@@ -634,7 +634,7 @@ services:
         max-file: "3"
 
   pulp_worker:
-    image: pulp/pulp-minimal:3.49.1
+    image: pulp/pulp-minimal:3.114.1
     command: ['pulp-worker']
     user: pulp
     depends_on:
@@ -659,7 +659,7 @@ services:
   # nginx front end. Aliased to "pulp" so ALBS can reach it at http://pulp (the
   # old all-in-one service name); listens on :80 internally.
   pulp_web:
-    image: pulp/pulp-web:3.49.1
+    image: pulp/pulp-web:3.114.1
     command: ['/usr/bin/nginx.sh']
     hostname: pulp
     user: root

--- a/tests/test_scripts/test_packages_exporter.py
+++ b/tests/test_scripts/test_packages_exporter.py
@@ -1,25 +1,60 @@
-import os
+import logging
 
 import pytest
 
-from alws.config import settings
-from alws.models import SignKey
+from scripts.exporters.base_exporter import BasePulpExporter
 from scripts.exporters.packages_exporter import PackagesExporter
 from tests.mock_classes import BaseAsyncTestCase
 
-IN_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") is not None
+FAKE_SIGNATURE = "-----BEGIN PGP SIGNATURE-----\nfake\n-----END PGP SIGNATURE-----"
+
+
+def _make_exporter() -> PackagesExporter:
+    # Bypass __init__: it needs the createrepo_c binary, a Pulp client and
+    # writable cache dirs, none of which are relevant to the sign flow (and
+    # createrepo_c isn't installed in the test image). We only exercise the
+    # sign-server calls, which need nothing but a logger.
+    exporter = PackagesExporter.__new__(PackagesExporter)
+    exporter.logger = logging.getLogger("test-packages-exporter")
+    return exporter
 
 
 class TestPackagesExporter(BaseAsyncTestCase):
-    @pytest.mark.skipif(
-        not settings.test_sign_key_id or IN_GITHUB_ACTIONS,
-        reason="Testing sign key is not provided or sign_file service is unavailable",
-    )
-    async def test_repomd_signer(self, sign_key: SignKey, tmp_path):
-        exporter = PackagesExporter(repodata_cache_dir='~/.cache/pulp_exporter')
-        key_id = sign_key.keyid
+    async def test_repomd_signer(self, monkeypatch, tmp_path):
+        # Stub the only network chokepoint. The sign server exposes 'token'
+        # (returns an auth token) and 'sign' (returns the detached ASC).
+        async def fake_make_request(self, method, endpoint, **kwargs):
+            if endpoint == "token":
+                return {"token": "test-token"}
+            if endpoint == "sign":
+                return FAKE_SIGNATURE
+            raise AssertionError(f"unexpected endpoint {endpoint!r}")
+
+        monkeypatch.setattr(BasePulpExporter, "make_request", fake_make_request)
+
+        exporter = _make_exporter()
         token = await exporter.get_sign_server_token()
-        temp_file = tmp_path / "tempfile.txt"
-        temp_file.write_bytes(b'Hello world!')
-        res = await exporter.sign_repomd_xml(str(temp_file), key_id, token)
-        assert res['error'] is None
+        assert token == "test-token"
+
+        temp_file = tmp_path / "repomd.xml"
+        temp_file.write_bytes(b"Hello world!")
+        res = await exporter.sign_repomd_xml(temp_file, "1234567890ABCDEF", token)
+        assert res["error"] is None
+        assert res["asc_content"] == FAKE_SIGNATURE
+
+    async def test_repomd_signer_reports_error(self, monkeypatch, tmp_path):
+        # An empty sign-server response is treated as a failure. max_attempts=1
+        # so no retry backoff sleep is hit.
+        async def fake_make_request(self, method, endpoint, **kwargs):
+            return ""
+
+        monkeypatch.setattr(BasePulpExporter, "make_request", fake_make_request)
+
+        exporter = _make_exporter()
+        temp_file = tmp_path / "repomd.xml"
+        temp_file.write_bytes(b"Hello world!")
+        res = await exporter.sign_repomd_xml(
+            temp_file, "1234567890ABCDEF", "test-token", max_attempts=1
+        )
+        assert res["asc_content"] is None
+        assert res["error"] == "sign server returned empty response"


### PR DESCRIPTION
- Bump pulp-minimal/pulp-web images 3.49.1 -> 3.114.1 in docker-compose
- Remove explicit Prometheus() broker middleware: the dramatiq worker CLI already registers it by default, and a second registration duplicates the collectors and conflicts; update surrounding comments accordingly
- pulp_client: raise PULP_SEMAPHORE 5 -> 20, lower wait_for_task poll 5s -> 1s, always include a packages key in the modulemd payload, and paginate via the next link directly to avoid duplicate query params