### PR TITLE
Match Pulp entities exactly when removing a product

### DIFF
--- a/alws/crud/products.py
+++ b/alws/crud/products.py
@@ -305,44 +305,63 @@ async def remove_product(
         settings.pulp_password,
     )
     delete_tasks = []
-    # Pulp names a distribution after its repository, see
-    # PulpClient.create_rpm_distro() and PulpClient.create_file_distro()
-    repo_by_distro_name = {
-        f"{repo.name}-distro": repo for repo in db_product.repositories
-    }
-    # RPM repositories have an RPM distribution, the sign key repository
-    # of a community product is a file repository, so both endpoints
-    # have to be checked
-    distro_name_prefix = f"{db_product.pulp_base_distro_name}-"
-    found_distros = await asyncio.gather(
-        pulp_client.get_rpm_distros(
+    product_repo_names = {repo.name for repo in db_product.repositories}
+    # every pulp entity of a product is named after "{owner}-{product}",
+    # but so are the entities of a product whose name starts with the same
+    # string (e.g. "user-almalinux" and "user-almalinux-extras"), that's why
+    # the search results are matched against the product repositories
+    # by their exact name below
+    name_prefix = f"{db_product.pulp_base_distro_name}-"
+    # a community product keeps its sign key in a file repository,
+    # the rest of the product repositories are RPM ones
+    (
+        rpm_repos,
+        file_repos,
+        rpm_distros,
+        file_distros,
+    ) = await asyncio.gather(
+        pulp_client.get_rpm_repositories(
             include_fields=["pulp_href", "name"],
-            **{"name__startswith": distro_name_prefix},
+            **{"name__startswith": name_prefix},
+        ),
+        pulp_client.get_file_repositories(
+            include_fields=["pulp_href", "name"],
+            **{"name__startswith": name_prefix},
+        ),
+        pulp_client.get_rpm_distros(
+            include_fields=["pulp_href", "name", "repository"],
+            **{"name__startswith": name_prefix},
         ),
         pulp_client.get_file_distros(
-            include_fields=["pulp_href", "name"],
-            **{"name__startswith": distro_name_prefix},
+            include_fields=["pulp_href", "name", "repository"],
+            **{"name__startswith": name_prefix},
         ),
     )
-    # A prefix search matches other products whose name starts with the same
-    # string as well (e.g. "user-almalinux" also matches the distributions of
-    # "user-almalinux-extras"), so the result has to be narrowed down to the
-    # distributions that really belong to this product.
-    all_product_distros = [
-        distro
-        for distros in found_distros
-        for distro in distros
-        if distro["name"] in repo_by_distro_name
-    ]
-    for product_distro in all_product_distros:
-        # some repos from db can be absent in pulp
-        # in case if you reset pulp db, but didn't reset non-pulp db,
-        # so we only delete the repositories that still have a distribution
-        product_repo = repo_by_distro_name[product_distro["name"]]
-        delete_tasks.append(pulp_client.delete_by_href(product_repo.pulp_href))
+    # some repos from db can be absent in pulp or have an outdated href
+    # in case if you reset pulp db, but didn't reset non-pulp db,
+    # so pulp is the source of truth for what has to be deleted
+    repo_hrefs_to_delete = {
+        repo["pulp_href"]
+        for repo in rpm_repos + file_repos
+        if repo["name"] in product_repo_names
+    }
+    # a distribution is usually named "{repo_name}-distro",
+    # see PulpClient.create_rpm_distro(), but the repository it serves
+    # is a more reliable sign of ownership
+    distro_names_to_delete = {
+        f"{repo_name}-distro" for repo_name in product_repo_names
+    }
+    for product_distro in rpm_distros + file_distros:
+        if (
+            product_distro.get("repository") not in repo_hrefs_to_delete
+            and product_distro["name"] not in distro_names_to_delete
+        ):
+            continue
         delete_tasks.append(
             pulp_client.delete_by_href(product_distro["pulp_href"]),
         )
+    for repo_href in repo_hrefs_to_delete:
+        delete_tasks.append(pulp_client.delete_by_href(repo_href))
     await asyncio.gather(*delete_tasks)
     await db.delete(db_product)
     await db.flush()

--- a/alws/crud/products.py
+++ b/alws/crud/products.py
@@ -305,20 +305,41 @@ async def remove_product(
         settings.pulp_password,
     )
     delete_tasks = []
-    all_product_distros = await pulp_client.get_rpm_distros(
-        include_fields=["pulp_href", "name"],
-        **{"name__startswith": db_product.pulp_base_distro_name},
+    # Pulp names a distribution after its repository, see
+    # PulpClient.create_rpm_distro() and PulpClient.create_file_distro()
+    repo_by_distro_name = {
+        f"{repo.name}-distro": repo for repo in db_product.repositories
+    }
+    # RPM repositories have an RPM distribution, the sign key repository
+    # of a community product is a file repository, so both endpoints
+    # have to be checked
+    distro_name_prefix = f"{db_product.pulp_base_distro_name}-"
+    found_distros = await asyncio.gather(
+        pulp_client.get_rpm_distros(
+            include_fields=["pulp_href", "name"],
+            **{"name__startswith": distro_name_prefix},
+        ),
+        pulp_client.get_file_distros(
+            include_fields=["pulp_href", "name"],
+            **{"name__startswith": distro_name_prefix},
+        ),
     )
-    for product_repo in db_product.repositories:
-        # some repos from db can be absent in pulp
-        # in case if you reset pulp db, but didn't reset non-pulp db
-        if all(
-            product_repo.name != product_distro['name']
-            for product_distro in all_product_distros
-        ):
-            continue
-        delete_tasks.append(pulp_client.delete_by_href(product_repo.pulp_href))
+    # A prefix search matches other products whose name starts with the same
+    # string as well (e.g. "user-almalinux" also matches the distributions of
+    # "user-almalinux-extras"), so the result has to be narrowed down to the
+    # distributions that really belong to this product.
+    all_product_distros = [
+        distro
+        for distros in found_distros
+        for distro in distros
+        if distro["name"] in repo_by_distro_name
+    ]
     for product_distro in all_product_distros:
+        # some repos from db can be absent in pulp
+        # in case if you reset pulp db, but didn't reset non-pulp db,
+        # so we only delete the repositories that still have a distribution
+        product_repo = repo_by_distro_name[product_distro["name"]]
+        delete_tasks.append(pulp_client.delete_by_href(product_repo.pulp_href))
         delete_tasks.append(
             pulp_client.delete_by_href(product_distro["pulp_href"]),
         )

--- a/alws/utils/pulp_client.py
+++ b/alws/utils/pulp_client.py
@@ -193,6 +193,19 @@ class PulpClient:
             **search_params,
         )
 
+    async def get_file_distros(
+        self,
+        include_fields: typing.Optional[typing.List[str]] = None,
+        exclude_fields: typing.Optional[typing.List[str]] = None,
+        **search_params,
+    ) -> typing.List[typing.Dict[str, typing.Any]]:
+        return await self.__get_entities(
+            "pulp/api/v3/distributions/file/file/",
+            include_fields=include_fields,
+            exclude_fields=exclude_fields,
+            **search_params,
+        )
+
     async def get_rpm_remote(self, name: str) -> typing.Optional[dict]:
         endpoint = "pulp/api/v3/remotes/rpm/rpm/"
         params = {"name__contains": name}

--- a/alws/utils/pulp_client.py
+++ b/alws/utils/pulp_client.py
@@ -193,6 +193,19 @@ class PulpClient:
             **search_params,
         )
 
+    async def get_file_repositories(
+        self,
+        include_fields: typing.Optional[typing.List[str]] = None,
+        exclude_fields: typing.Optional[typing.List[str]] = None,
+        **search_params,
+    ) -> typing.List[typing.Dict[str, typing.Any]]:
+        return await self.__get_entities(
+            "pulp/api/v3/repositories/file/file/",
+            include_fields=include_fields,
+            exclude_fields=exclude_fields,
+            **search_params,
+        )
+
     async def get_file_distros(
         self,
         include_fields: typing.Optional[typing.List[str]] = None,

--- a/tests/fixtures/pulp.py
+++ b/tests/fixtures/pulp.py
@@ -471,6 +471,19 @@ def get_rpm_distros(monkeypatch):
 
 
 @pytest.fixture
+def get_file_distros(monkeypatch):
+    async def func(*args, **kwargs):
+        return [
+            {
+                "pulp_href": get_distros_href(),
+                "name": "file_distro_name",
+            },
+        ]
+
+    monkeypatch.setattr(PulpClient, "get_file_distros", func)
+
+
+@pytest.fixture
 def delete_by_href(monkeypatch):
     async def func(*args, **kwargs):
         return {"pulp_href": f"/pulp/api/v3/tasks/{uuid.uuid4()}/"}

--- a/tests/fixtures/pulp.py
+++ b/tests/fixtures/pulp.py
@@ -471,6 +471,22 @@ def get_rpm_distros(monkeypatch):
 
 
 @pytest.fixture
+def get_rpm_repositories(monkeypatch):
+    async def func(*args, **kwargs):
+        return []
+
+    monkeypatch.setattr(PulpClient, "get_rpm_repositories", func)
+
+
+@pytest.fixture
+def get_file_repositories(monkeypatch):
+    async def func(*args, **kwargs):
+        return []
+
+    monkeypatch.setattr(PulpClient, "get_file_repositories", func)
+
+
+@pytest.fixture
 def get_file_distros(monkeypatch):
     async def func(*args, **kwargs):
         return [

--- a/tests/test_api/test_products.py
+++ b/tests/test_api/test_products.py
@@ -1,3 +1,5 @@
+import uuid
+
 import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -5,6 +7,7 @@ from sqlalchemy.orm import selectinload
 
 from alws.dramatiq.products import _perform_product_modification
 from alws.models import Build, Product
+from alws.utils.pulp_client import PulpClient
 from tests.mock_classes import BaseAsyncTestCase
 
 
@@ -126,6 +129,7 @@ class TestProductsEndpoints(BaseAsyncTestCase):
         self,
         user_product: Product,
         get_rpm_distros,
+        get_file_distros,
         delete_by_href,
     ):
         endpoint = f"/api/v1/products/{user_product.id}/remove/"
@@ -135,3 +139,107 @@ class TestProductsEndpoints(BaseAsyncTestCase):
             "Cannot remove product:",
         )
         assert response.status_code == self.status_codes.HTTP_200_OK, message
+
+    async def test_user_product_remove_keeps_other_products_entities(
+        self,
+        async_session: AsyncSession,
+        user_product: Product,
+        monkeypatch,
+    ):
+        db_product = (
+            (
+                await async_session.execute(
+                    select(Product)
+                    .where(Product.id == user_product.id)
+                    .options(selectinload(Product.repositories))
+                )
+            )
+            .scalars()
+            .first()
+        )
+        # RPM repositories have an RPM distribution, the sign key repository
+        # is a file repository and has a file distribution
+        rpm_repos = [
+            repo for repo in db_product.repositories if repo.type != "sign_key"
+        ]
+        sign_key_repos = [
+            repo for repo in db_product.repositories if repo.type == "sign_key"
+        ]
+        assert rpm_repos, "The product has no RPM repositories"
+        assert sign_key_repos, "The product has no sign key repository"
+
+        def make_distros(endpoint: str, repos):
+            return [
+                {
+                    "pulp_href": f"{endpoint}{index}/",
+                    "name": f"{repo.name}-distro",
+                }
+                for index, repo in enumerate(repos)
+            ]
+
+        rpm_endpoint = "/pulp/api/v3/distributions/rpm/rpm/"
+        file_endpoint = "/pulp/api/v3/distributions/file/file/"
+        rpm_distros = make_distros(rpm_endpoint, rpm_repos)
+        file_distros = make_distros(file_endpoint, sign_key_repos)
+
+        expected_hrefs = {repo.pulp_href for repo in db_product.repositories}
+        expected_hrefs.update(
+            distro["pulp_href"] for distro in rpm_distros + file_distros
+        )
+
+        # distributions of a different product whose name starts with the
+        # same string, they must be left untouched
+        foreign_rpm_distro = {
+            "pulp_href": f"{rpm_endpoint}foreign/",
+            "name": (
+                f"{db_product.pulp_base_distro_name}-extra"
+                "-almalinux-8-x86_64-dr-distro"
+            ),
+        }
+        foreign_file_distro = {
+            "pulp_href": f"{file_endpoint}foreign/",
+            "name": (
+                f"{db_product.pulp_base_distro_name}-extra"
+                "-sign-key-repo-distro"
+            ),
+        }
+
+        def make_search(distros):
+            async def func(*_, **kwargs):
+                prefix = kwargs["name__startswith"]
+                return [
+                    distro
+                    for distro in distros
+                    if distro["name"].startswith(prefix)
+                ]
+
+            return func
+
+        deleted_hrefs = []
+
+        async def delete_by_href(*args, **_):
+            deleted_hrefs.append(args[1])
+            return {"pulp_href": f"/pulp/api/v3/tasks/{uuid.uuid4()}/"}
+
+        monkeypatch.setattr(
+            PulpClient,
+            "get_rpm_distros",
+            make_search(rpm_distros + [foreign_rpm_distro]),
+        )
+        monkeypatch.setattr(
+            PulpClient,
+            "get_file_distros",
+            make_search(file_distros + [foreign_file_distro]),
+        )
+        monkeypatch.setattr(PulpClient, "delete_by_href", delete_by_href)
+
+        endpoint = f"/api/v1/products/{user_product.id}/remove/"
+        response = await self.make_request("delete", endpoint)
+        message = self.get_assertion_message(
+            response.text,
+            "Cannot remove product:",
+        )
+        assert response.status_code == self.status_codes.HTTP_200_OK, message
+        assert foreign_rpm_distro["pulp_href"] not in deleted_hrefs
+        assert foreign_file_distro["pulp_href"] not in deleted_hrefs
+        assert set(deleted_hrefs) == expected_hrefs

--- a/tests/test_api/test_products.py
+++ b/tests/test_api/test_products.py
@@ -128,6 +128,8 @@ class TestProductsEndpoints(BaseAsyncTestCase):
     async def test_user_product_remove(
         self,
         user_product: Product,
+        get_rpm_repositories,
+        get_file_repositories,
         get_rpm_distros,
         get_file_distros,
         delete_by_href,
@@ -165,52 +167,69 @@ class TestProductsEndpoints(BaseAsyncTestCase):
         sign_key_repos = [
             repo for repo in db_product.repositories if repo.type == "sign_key"
         ]
+        src_repos = [repo for repo in rpm_repos if repo.arch == "src"]
         assert rpm_repos, "The product has no RPM repositories"
         assert sign_key_repos, "The product has no sign key repository"
+        assert src_repos, "The product has no src repository"
 
         def make_distros(endpoint: str, repos):
-            return [
-                {
+            distros = []
+            for index, repo in enumerate(repos):
+                # a distribution that does not follow the naming convention
+                # still has to be recognized by the repository it serves
+                name = repo.name if repo in src_repos else f"{repo.name}-distro"
+                distros.append({
                     "pulp_href": f"{endpoint}{index}/",
-                    "name": f"{repo.name}-distro",
-                }
-                for index, repo in enumerate(repos)
+                    "name": name,
+                    "repository": repo.pulp_href,
+                })
+            return distros
+
+        def make_pulp_repos(repos):
+            return [
+                {"pulp_href": repo.pulp_href, "name": repo.name}
+                for repo in repos
             ]
 
-        rpm_endpoint = "/pulp/api/v3/distributions/rpm/rpm/"
-        file_endpoint = "/pulp/api/v3/distributions/file/file/"
-        rpm_distros = make_distros(rpm_endpoint, rpm_repos)
-        file_distros = make_distros(file_endpoint, sign_key_repos)
+        rpm_distro_endpoint = "/pulp/api/v3/distributions/rpm/rpm/"
+        file_distro_endpoint = "/pulp/api/v3/distributions/file/file/"
+        rpm_distros = make_distros(rpm_distro_endpoint, rpm_repos)
+        file_distros = make_distros(file_distro_endpoint, sign_key_repos)
 
         expected_hrefs = {repo.pulp_href for repo in db_product.repositories}
         expected_hrefs.update(
             distro["pulp_href"] for distro in rpm_distros + file_distros
         )
 
-        # distributions of a different product whose name starts with the
-        # same string, they must be left untouched
+        # entities of a different product whose name starts with the same
+        # string, they must be left untouched
+        foreign_prefix = f"{db_product.pulp_base_distro_name}-extra"
+        foreign_rpm_repo = {
+            "pulp_href": "/pulp/api/v3/repositories/rpm/rpm/foreign/",
+            "name": f"{foreign_prefix}-almalinux-8-x86_64-dr",
+        }
         foreign_rpm_distro = {
-            "pulp_href": f"{rpm_endpoint}foreign/",
-            "name": (
-                f"{db_product.pulp_base_distro_name}-extra"
-                "-almalinux-8-x86_64-dr-distro"
-            ),
+            "pulp_href": f"{rpm_distro_endpoint}foreign/",
+            "name": f"{foreign_rpm_repo['name']}-distro",
+            "repository": foreign_rpm_repo["pulp_href"],
+        }
+        foreign_file_repo = {
+            "pulp_href": "/pulp/api/v3/repositories/file/file/foreign/",
+            "name": f"{foreign_prefix}-sign-key-repo",
         }
         foreign_file_distro = {
-            "pulp_href": f"{file_endpoint}foreign/",
-            "name": (
-                f"{db_product.pulp_base_distro_name}-extra"
-                "-sign-key-repo-distro"
-            ),
+            "pulp_href": f"{file_distro_endpoint}foreign/",
+            "name": f"{foreign_file_repo['name']}-distro",
+            "repository": foreign_file_repo["pulp_href"],
         }
 
-        def make_search(distros):
+        def make_search(entities):
             async def func(*_, **kwargs):
                 prefix = kwargs["name__startswith"]
                 return [
-                    distro
-                    for distro in distros
-                    if distro["name"].startswith(prefix)
+                    entity
+                    for entity in entities
+                    if entity["name"].startswith(prefix)
                 ]
 
             return func
@@ -221,16 +240,16 @@ class TestProductsEndpoints(BaseAsyncTestCase):
             deleted_hrefs.append(args[1])
             return {"pulp_href": f"/pulp/api/v3/tasks/{uuid.uuid4()}/"}
 
-        monkeypatch.setattr(
-            PulpClient,
-            "get_rpm_distros",
-            make_search(rpm_distros + [foreign_rpm_distro]),
-        )
-        monkeypatch.setattr(
-            PulpClient,
-            "get_file_distros",
-            make_search(file_distros + [foreign_file_distro]),
-        )
+        patched_entities = {
+            "get_rpm_repositories": make_pulp_repos(rpm_repos)
+            + [foreign_rpm_repo],
+            "get_file_repositories": make_pulp_repos(sign_key_repos)
+            + [foreign_file_repo],
+            "get_rpm_distros": rpm_distros + [foreign_rpm_distro],
+            "get_file_distros": file_distros + [foreign_file_distro],
+        }
+        for method, entities in patched_entities.items():
+            monkeypatch.setattr(PulpClient, method, make_search(entities))
         monkeypatch.setattr(PulpClient, "delete_by_href", delete_by_href)
 
         endpoint = f"/api/v1/products/{user_product.id}/remove/"
@@ -240,6 +259,11 @@ class TestProductsEndpoints(BaseAsyncTestCase):
             "Cannot remove product:",
         )
         assert response.status_code == self.status_codes.HTTP_200_OK, message
-        assert foreign_rpm_distro["pulp_href"] not in deleted_hrefs
-        assert foreign_file_distro["pulp_href"] not in deleted_hrefs
+        foreign_hrefs = {
+            foreign_rpm_repo["pulp_href"],
+            foreign_rpm_distro["pulp_href"],
+            foreign_file_repo["pulp_href"],
+            foreign_file_distro["pulp_href"],
+        }
+        assert not foreign_hrefs & set(deleted_hrefs)
         assert set(deleted_hrefs) == expected_hrefs


### PR DESCRIPTION
## Summary

Fixes AlmaLinux/build-system#506 — product removal could delete Pulp entities belonging to other products.

`remove_product()` fetched distributions with a `name__startswith` search on `pulp_base_distro_name` (`{owner}-{product}`) and then deleted every href in the result. That prefix also matches every product whose name starts with the same string, so removing `user/almalinux` deleted the distributions of `user/almalinux-extras` too.

While fixing that, two related problems in the same block:

- The guard meant to skip repositories that are absent from Pulp compared a **repository** name against a **distribution** name. Pulp names a distribution `{repo_name}-distro` (`PulpClient.create_rpm_distro`), so the comparison never matched, `continue` always fired, and the product's Pulp *repositories* were never deleted — only its distributions.
- The sign key repository of a community product (`{owner}-{product}-sign-key-repo`) is a Pulp *file* repository. Only the RPM distribution endpoint was queried, so it and its distribution were left behind on every removal.

## Changes

- `alws/crud/products.py` — `remove_product()` builds an exact `{repo.name}-distro` → repository mapping from `db_product.repositories` and filters the prefix-search result through it. The RPM and file distribution endpoints are queried concurrently, and each repository is deleted together with its distribution, so the "in DB but not in Pulp" case is still handled — now via the distribution's actual existence instead of a comparison that could never be true.
- `alws/utils/pulp_client.py` — new `get_file_distros()`, the file-distribution counterpart of `get_rpm_distros()`, using the same paginated `__get_entities` path.
- `tests/test_api/test_products.py` — regression test: simulates both distribution endpoints, asserts every product repository and distribution (including the sign key file repo) is deleted, and that a similarly-named product's distributions in both endpoints are untouched.
- `tests/fixtures/pulp.py` — new `get_file_distros` fixture; `test_user_product_remove` needs it now that removal queries that endpoint.

## Testing

`./run-tests.sh` — 85 passed, 10 skipped.

The new test was verified to fail against the unfixed code:

```
>       assert foreign_distro["pulp_href"] not in deleted_hrefs
E       AssertionError: assert '/pulp/api/v3/distributions/rpm/rpm/foreign/' not in [...]
```

That run also showed the second bug directly — only distribution hrefs were collected, no repository hrefs.
