### PR TITLE
Align metadata uploader script with standard async setup

### DIFF
--- a/scripts/upload_repository_metadata.py
+++ b/scripts/upload_repository_metadata.py
@@ -1,15 +1,14 @@
+import asyncio
 import logging
 import os.path
 import sys
 from argparse import ArgumentParser
-from contextlib import asynccontextmanager
 from io import BytesIO
 
 from fastapi import UploadFile
-from fastapi_sqla import open_async_session
-from syncer import sync
 
-from alws.dependencies import get_async_db_key
+from alws.dependencies import get_async_db_session
+from alws.utils.fastapi_sqla_setup import setup_all
 from alws.utils.uploader import MetadataUploader
 
 
@@ -32,6 +31,7 @@ async def main():
     if not args.modules_file and not args.comps_file:
         logger.error('Module or comps file should be specified')
         return 1
+    await setup_all()
     module_content = None
     comps_content = None
     if args.modules_file:
@@ -44,7 +44,7 @@ async def main():
             os.path.abspath(os.path.expanduser(args.comps_file)), 'rt'
         ) as f:
             comps_content = UploadFile(BytesIO(f.read().encode('utf-8')))
-    async with open_async_session(get_async_db_key()) as session:
+    async with get_async_db_session() as session:
         uploader = MetadataUploader(session, args.repo_name)
         await uploader.process_uploaded_files(
             module_content, comps_content, dry_run=args.dry_run
@@ -53,4 +53,4 @@ async def main():
 
 
 if __name__ == '__main__':
-    sys.exit(sync(main()))
+    sys.exit(asyncio.run(main()))


### PR DESCRIPTION
## Summary

`scripts/upload_repository_metadata.py` was still on the legacy async entrypoint: `syncer.sync(main())` plus a hand-assembled `open_async_session(get_async_db_key())`, and it never called `setup_all()`. This aligns it with the pattern every other script in `scripts/` uses (see `scripts/noarch_checker.py`).

Note that the missing `setup_all()` looks like a latent bug rather than a cosmetic gap — `MetadataUploader` needs both the async session key and the sync `'pulp'` key (`alws/utils/uploader.py` calls `open_session('pulp')`), and `fastapi_sqla_setup.setup_all()` is what registers those session factories.

## Changes

- `scripts/upload_repository_metadata.py`
  - `sync(main())` -> `asyncio.run(main())`, dropping the `syncer` dependency
  - added `await setup_all()` at the top of `main()`, after arg validation so the early `return 1` path doesn't pay DB setup cost
  - `open_async_session(get_async_db_key())` -> the `get_async_db_session()` context manager from `alws.dependencies` (an `@asynccontextmanager` wrapping the exact same call, so commit/rollback semantics are unchanged)
  - removed the now-unused `syncer`, `open_async_session`, `get_async_db_key` and `asynccontextmanager` imports

## Testing

- `python -m py_compile` passes; `sys.exit(...)` still propagates the `return 1` exit code from the no-file-specified path
- Verified the new imports resolve: `get_async_db_session` at `alws/dependencies.py:26`, `setup_all` at `alws/utils/fastapi_sqla_setup.py:16`
- Diffed against the ~25 sibling scripts already on this pattern to confirm ordering (`setup_all()` before any session is opened)
- No automated test covers this script; not run against a live DB/Pulp instance.