### PR TITLE
Add Prometheus collector service for web_server and dramatiq workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,37 @@ sleep 25
 docker exec -it albs-web-server_pulp_1 bash -c 'pulpcore-manager reset-admin-password --password="admin"'
 ```
 
+# Metrics
+
+The stack ships a Prometheus collector as the `prometheus` compose service. It
+comes up with `docker-compose up -d` like everything else and is browsable at
+<http://localhost:9090> (Status → Target health lists every target).
+
+It scrapes the ALBS application services over the compose network, by service
+name — targets need no published host ports:
+
+| Target | Endpoint | Metrics |
+|---|---|---|
+| `web_server` | `:8000/metrics/` | `http_request_duration_seconds`, `http_requests_total`, `function_duration_seconds` (see `alws/utils/metrics.py`) |
+| `task_queue`, `task_queue_sources`, `task_queue_builds`, `task_queue_errata`, `task_queue_releases`, `task_queue_sign`, `task_queue_product_modify`, `task_queue_tests` | `:9191/metrics` | `dramatiq_messages_total`, `dramatiq_message_errors_total`, `dramatiq_message_retries_total`, `dramatiq_message_rejects_total`, `dramatiq_messages_inprogress`, `dramatiq_message_duration_milliseconds` |
+
+Scrape targets live in `monitoring/prometheus.yml`. Every worker target carries
+`service` and `queue` labels, so `up{queue="sign"} == 0` is a ready-made alert
+for a dead worker. Data is kept for 15 days in the `prometheus_data` volume.
+
+**Adding a worker service:** add the compose service *and* a target block under
+the `albs-dramatiq` job, with a `queue` label matching the new `-Q` argument.
+Validate with `docker run --rm -v "$PWD/monitoring/prometheus.yml:/p.yml"
+--entrypoint promtool prom/prometheus:v3.14.0 check config /p.yml`.
+Apply config edits with `docker-compose restart prometheus` (the TSDB is in a
+named volume, so no data is lost).
+
+**Worker metrics are served by dramatiq's *default* middleware.** Do not add
+`Prometheus()` to the broker in `alws/dramatiq/__init__.py` — `default_middleware`
+already includes it, and a second registration makes the CLI spawn two
+exposition servers, the second dying with `OSError: [Errno 98] Address already
+in use` on :9191.
+
 # Scheduling tasks 
 
 Web-server works with multiple parts of the Build System. Web-server works with API requests that are divided by usage. 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -724,6 +724,32 @@ services:
         max-size: "100Mb"
         max-file: "3"
 
+  # Metrics collector for the ALBS application services. Scrapes web_server's
+  # /metrics and every task_queue_* worker's dramatiq exposition server on
+  # :9191 by compose service name — see monitoring/prometheus.yml. Targets need
+  # no host port mappings; only Prometheus' own UI/API is published.
+  prometheus:
+    image: prom/prometheus:v3.14.0
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--storage.tsdb.retention.time=15d"
+      # --web.enable-lifecycle is deliberately NOT set: :9090 is published to
+      # the host, and it would expose remote /-/reload and /-/quit. Pick up
+      # monitoring/prometheus.yml edits with `docker-compose restart prometheus`
+      # — the TSDB lives in a named volume, so nothing is lost.
+    ports:
+      - "9090:9090"
+    volumes:
+      - "./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:z"
+      - "prometheus_data:/prometheus"
+    restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "100Mb"
+        max-file: "3"
+
   immudb:
     image: codenotary/immudb:1.5
     ports:
@@ -770,6 +796,8 @@ services:
 volumes:
   redis:
   pulp_redis:
+  # Prometheus TSDB for the metrics collector (see the prometheus service).
+  prometheus_data:
   # Pulp content store. Named volume (not a host bind mount) so Docker populates
   # it from the image — preserving /var/lib/pulp/tmp and the uid:700 (pulp)
   # ownership the pulp-minimal services need.

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,85 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Prometheus scrape config for the ALBS stack.
+#
+# Prometheus runs as a compose service on the stack's default network, so every
+# target below is reached by its compose service name — no host port mappings
+# and no container IPs are needed.
+#
+# Two kinds of target:
+#   * web_server    — FastAPI, /metrics mounted by alws.app (alws/utils/metrics.py):
+#                     http_request_duration_seconds, http_requests_total,
+#                     function_duration_seconds.
+#   * task_queue_*  — dramatiq workers. The worker CLI's default Prometheus
+#                     middleware serves dramatiq_* metrics on :9191 (it answers
+#                     any GET path). See alws/dramatiq/__init__.py — the
+#                     middleware must NOT be registered a second time there.
+#
+# When a worker service is scaled (docker compose up --scale task_queue=N),
+# the service name resolves to every replica's IP and Prometheus scrapes them
+# all; the instance label keeps them apart.
+# ─────────────────────────────────────────────────────────────────────────────
+global:
+  scrape_interval: 15s
+  scrape_timeout: 10s
+  evaluation_interval: 15s
+  external_labels:
+    stack: albs
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: ["localhost:9090"]
+
+  # Trailing slash is deliberate: alws.app mounts the metrics ASGI app at
+  # "/metrics", so Starlette answers the bare path with a 307 to "/metrics/".
+  # Prometheus would follow it, but scraping the final path directly avoids a
+  # redirect round-trip on every single scrape.
+  - job_name: albs-web-server
+    metrics_path: /metrics/
+    static_configs:
+      - targets: ["web_server:8000"]
+        labels:
+          service: web_server
+
+  # One dramatiq exposition server per worker container, all on :9191 (one per
+  # container, not per --processes worker — the CLI starts a single fork).
+  #
+  # The queue label mirrors the -Q argument in docker-compose.yml. It overlaps
+  # with the queue_name label dramatiq puts on its own samples, but it is also
+  # attached to the synthetic up/scrape_* series — so `up{queue="sign"} == 0`
+  # alerts on a dead sign worker even when it has processed nothing yet.
+  - job_name: albs-dramatiq
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["task_queue:9191"]
+        labels:
+          service: task_queue
+          queue: default
+      - targets: ["task_queue_sources:9191"]
+        labels:
+          service: task_queue_sources
+          queue: sources
+      - targets: ["task_queue_builds:9191"]
+        labels:
+          service: task_queue_builds
+          queue: builds
+      - targets: ["task_queue_errata:9191"]
+        labels:
+          service: task_queue_errata
+          queue: errata
+      - targets: ["task_queue_releases:9191"]
+        labels:
+          service: task_queue_releases
+          queue: releases
+      - targets: ["task_queue_sign:9191"]
+        labels:
+          service: task_queue_sign
+          queue: sign
+      - targets: ["task_queue_product_modify:9191"]
+        labels:
+          service: task_queue_product_modify
+          queue: product_modify
+      - targets: ["task_queue_tests:9191"]
+        labels:
+          service: task_queue_tests
+          queue: tests


### PR DESCRIPTION
Resolves: https://github.com/AlmaLinux/build-system/issues/540

## Part 1 — the crash in #540 is already fixed on `master`

The duplicate `Prometheus()` registration was removed in c35f672, already merged. No code change was needed here; I verified it instead of assuming:

- No `add_middleware(Prometheus())` and no `dramatiq.middleware.prometheus` import remains in `alws/`.
- Confirmed against dramatiq v1.17.1 that `default_middleware` does include `Prometheus`, so the explanatory comment in `alws/dramatiq/__init__.py` is accurate.
- **Live check** — built the task-queue image and ran a worker against RabbitMQ exactly as compose does. Boot log shows exactly one exposition server and no traceback:

```
[dramatiq.MainProcess] [INFO] Dramatiq '1.17.1' is booting up.
...
[PID 166] [dramatiq.ForkProcess(0)] [INFO] Fork process
  'dramatiq.middleware.prometheus:_run_exposition_server' is ready for action.
```

## Part 2 — this PR: the collector

Nothing scraped the endpoints added in #1230, so both the workers' `:9191` and the web server's `/metrics` were serving data nobody collected. This adds a `prometheus` compose service (always on, like the rest of the stack) with scrape targets in `monitoring/prometheus.yml`:

| Target | Endpoint | Metrics |
|---|---|---|
| `web_server` | `:8000/metrics/` | `http_request_duration_seconds`, `http_requests_total`, `function_duration_seconds` |
| the 8 `task_queue_*` workers | `:9191/metrics` | `dramatiq_messages_total`, `_message_errors_total`, `_message_retries_total`, `_message_rejects_total`, `_messages_inprogress`, `_message_duration_milliseconds` |

Targets are reached by compose service name over the default network, so **no target needs a published host port** — only Prometheus' own UI is exposed, on `:9090`. Worker targets carry `service` and `queue` labels, so `up{queue="sign"} == 0` alerts on a dead worker before it has processed anything. 15d retention in the `prometheus_data` named volume.

## Verification

Verified end-to-end on a throwaway network, not only by config inspection:

| Check | Result |
|---|---|
| `promtool check config` | SUCCESS |
| All 10 targets resolve to real compose service names | pass (script-diffed against `docker-compose.yml`) |
| All 8 `queue` labels match the actual `-Q` args | pass (script-diffed) |
| `web_server` target | UP; real `http_requests_total{endpoint="/docs"}` ingested |
| Worker target | UP; enqueued a task and `dramatiq_messages_total` / `_errors_total` / `_duration_milliseconds` came back queryable with correct `service` + `queue` labels |

Two things the live test caught that config review alone would have missed:

1. **`/metrics` 307-redirects to `/metrics/`.** `alws.app` *mounts* the metrics ASGI app, so the bare path always redirects. Prometheus follows it, but `metrics_path` is set to `/metrics/` to drop a redirect round-trip from every scrape.
2. **A worker's `:9191` returns HTTP 200 with an empty body until it processes its first message.** That is a healthy target with zero samples, not a broken one — worth knowing before someone reads it as a failure. It is also why the `queue` target label exists: it lands on the synthetic `up`/`scrape_*` series, which are present even when the worker has no `dramatiq_*` samples yet.

## Notes for review

- `--web.enable-lifecycle` is deliberately **not** set: `:9090` is published to the host and the flag would expose remote `/-/reload` and `/-/quit`. Config edits apply with `docker-compose restart prometheus`; the TSDB is in a named volume, so nothing is lost. Happy to flip this if you'd rather have hot reload.
- Scope is app-services only — no cAdvisor, node-exporter, or postgres/redis/rabbitmq exporters. Those would cover the remaining compose services (`pulp_*`, `build_node`, `gitea_listener`, ...) and can be a separate PR if wanted.
- README gains a `# Metrics` section documenting the targets, how to add a worker, and — to keep #540 from recurring — that worker metrics come from dramatiq's *default* middleware and must never be registered a second time.
