### PR TITLE
Expose every release a build has been put into

### DIFF
--- a/alws/crud/build.py
+++ b/alws/crud/build.py
@@ -239,6 +239,39 @@ async def get_builds(
     return query.scalars().all()
 
 
+async def get_build_releases(
+    db: AsyncSession,
+    build_id: int,
+) -> typing.List[build_schema.BuildRelease]:
+    """
+    Every release the build has ever been put into, newest first.
+
+    models.Build.release_id only keeps the release the build got into last,
+    so the full history has to be looked up from the releases side. Columns
+    are selected explicitly to keep the huge release plan out of the query.
+    """
+    result = await db.execute(
+        select(
+            models.Release.id,
+            models.Release.status,
+            models.Release.created_at,
+            models.Platform.name.label("platform_name"),
+            models.Product.name.label("product_name"),
+        )
+        .join(
+            models.Platform,
+            models.Release.platform_id == models.Platform.id,
+        )
+        .join(
+            models.Product,
+            models.Release.product_id == models.Product.id,
+        )
+        .where(models.Release.build_ids.any(build_id))
+        .order_by(models.Release.id.desc())
+    )
+    return [build_schema.BuildRelease(**row._asdict()) for row in result.all()]
+
+
 async def get_module_preview(
     redis: aioredis.client.Redis,
     platform: models.Platform,

--- a/alws/routers/builds.py
+++ b/alws/routers/builds.py
@@ -117,6 +117,17 @@ async def get_build(
     return db_build
 
 
+@public_router.get(
+    '/{build_id}/releases/',
+    response_model=typing.List[build_schema.BuildRelease],
+)
+async def get_build_releases(
+    build_id: int,
+    db: AsyncSession = Depends(AsyncSessionDependency(key=get_async_db_key())),
+):
+    return await build_crud.get_build_releases(db, build_id)
+
+
 @router.patch('/{build_id}/restart-failed', status_code=status.HTTP_200_OK)
 async def restart_failed_build_items(
     build_id: int,

--- a/alws/schemas/build_schema.py
+++ b/alws/schemas/build_schema.py
@@ -248,6 +248,21 @@ class Product(BaseModel):
         from_attributes = True
 
 
+class BuildRelease(BaseModel):
+    """
+    A release the build is a part of, without the heavy release plan.
+    """
+
+    id: int
+    status: int
+    created_at: typing.Optional[datetime.datetime] = None
+    platform_name: typing.Optional[str] = None
+    product_name: typing.Optional[str] = None
+
+    class Config:
+        from_attributes = True
+
+
 class Build(BaseModel):
     id: int
     created_at: datetime.datetime

--- a/tests/test_api/test_releases.py
+++ b/tests/test_api/test_releases.py
@@ -158,6 +158,28 @@ class TestReleasesEndpoints(BaseAsyncTestCase):
         message = f"Cannot retrieve release:\n{response.text}"
         assert response.status_code == self.status_codes.HTTP_200_OK, message
 
+    async def test_get_build_releases(
+        self,
+    ):
+        self.headers = {}
+        response = await self.make_request(
+            "get",
+            "/api/v1/releases/",
+        )
+        release = response.json()[0]
+        build_id = release["build_ids"][0]
+        response = await self.make_request(
+            "get",
+            f"/api/v1/builds/{build_id}/releases/",
+        )
+        message = f"Cannot retrieve build releases:\n{response.text}"
+        assert response.status_code == self.status_codes.HTTP_200_OK, message
+        message = (
+            f"Release {release['id']} is missing "
+            f"among the releases of build {build_id}"
+        )
+        assert release["id"] in [row["id"] for row in response.json()], message
+
     async def test_revert_release(
         self,
         async_session: AsyncSession,


### PR DESCRIPTION
## Summary

`builds.release_id` only keeps the release a build got into last — `commit_release()` overwrites it for every build in the plan — so a build released more than once has no way of telling about its earlier releases. [Build 77924](https://build.almalinux.org/build/77924) is released both to `almalinux10-beta` ([51142](https://build.almalinux.org/release/51142)) and to AlmaLinux Kitten 10 ([50862](https://build.almalinux.org/release/50862)), and the API reports only the former.

The build-to-releases link lives on the other side, in `build_releases.build_ids`, and nothing exposes it: `GET /releases/` takes no `build_id`, and every release it returns carries the whole release plan — release 51142 alone serializes to 2.3 MB — so walking the release feed is not an option for a caller either.

## Changes

- `GET /builds/{build_id}/releases/` on the public router, since the build page is public. Returns `id`, `status`, `created_at`, `platform_name` and `product_name` per release, newest first.
- `build_crud.get_build_releases()` looks the history up from the releases side with `:build_id = ANY(build_releases.build_ids)`, joins platform and product, and selects columns explicitly so `plan` stays out of both the query and the response. Answers are hundreds of bytes.
- `build_schema.BuildRelease` for the returned rows.
- Reverted releases are returned along with the rest, each carrying its status. What to show is left to the caller — the frontend hides the reverted ones.

## Testing

- `tests/test_api/test_releases.py::test_get_build_releases`, placed before the revert tests so the release it looks up is still `COMPLETED`.
- The suite was not run here (needs the docker test stand); the change is `py_compile` clean and the array containment compiles to the expected `:id = ANY (build_releases.build_ids)`.
- `build_releases` holds ~8.4k rows, so the sequential scan behind `= ANY(...)` is cheap. A GIN index on `build_ids` can be added later if the table grows.

Frontend counterpart: https://github.com/AlmaLinux/albs-frontend/pull/605